### PR TITLE
Add scripts to setup automated code formatting

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# install development dependencies and setup git hook to automatically apply code-formatting
+pip install black
+pip install -e .
+# update location of Git hooks from default (.git/hooks) to the versioned folder .devtools/githooks
+git config core.hooksPath "githooks"

--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -1,0 +1,10 @@
+#!/bin/sh
+# runs black only on all python files committed in git
+echo "Running black."
+git ls-files | grep "\.py$" |  xargs black
+
+if [ $? -ne 0 ]; then
+ echo "Black should pass before commit! Run 'pip install .[extra,dev]' if you do not have it installed locally."
+ exit 1
+fi
+


### PR DESCRIPTION
Add a script to setup a pre-commit githook that automatically runs black for code formatting.
To install, run `bash dev_setup.sh`