### PR TITLE
#63 fix ruff `isort` ordering

### DIFF
--- a/examples/sinc/model.py
+++ b/examples/sinc/model.py
@@ -1,5 +1,6 @@
 import torch
 import torch.nn as nn
+
 from lobotomy.modules import Linear
 
 

--- a/examples/sinc/model.py
+++ b/examples/sinc/model.py
@@ -1,8 +1,5 @@
 import torch
 import torch.nn as nn
-
-from syne_tune.config_space import randint
-
 from lobotomy.modules import Linear
 
 

--- a/examples/sinc/search.py
+++ b/examples/sinc/search.py
@@ -4,13 +4,12 @@ from pathlib import Path
 import matplotlib.pyplot as plt
 import numpy as np
 import torch
+from estimate_efficiency import compute_mac_linear_layer
 from lobotomy.search import multi_objective_search
+from model import MLP
+from sinc_nas import f, validate
 from syne_tune.config_space import randint
 from torch.utils.data import DataLoader
-
-from .estimate_efficiency import compute_mac_linear_layer
-from .model import MLP
-from .sinc_nas import f, validate
 
 if __name__ == "__main__":
     parser = ArgumentParser()

--- a/examples/sinc/search.py
+++ b/examples/sinc/search.py
@@ -8,9 +8,9 @@ from lobotomy.search import multi_objective_search
 from syne_tune.config_space import randint
 from torch.utils.data import DataLoader
 
-from examples.sinc.estimate_efficiency import compute_mac_linear_layer
-from examples.sinc.model import MLP
-from examples.sinc.sinc_nas import f, validate
+from .estimate_efficiency import compute_mac_linear_layer
+from .model import MLP
+from .sinc_nas import f, validate
 
 if __name__ == "__main__":
     parser = ArgumentParser()
@@ -56,13 +56,14 @@ if __name__ == "__main__":
     model = MLP(input_dim=1, hidden_dim=args.hidden_dim, device=device)
 
     path = (
-        Path(args.st_checkpoint_dir)
-        / f"{args.training_strategy}_model_{args.hidden_dim}.pt"
+            Path(args.st_checkpoint_dir)
+            / f"{args.training_strategy}_model_{args.hidden_dim}.pt"
     )
     checkpoint = torch.load(path)
     model.load_state_dict(checkpoint["state"])
     model = model.to(device)
     model.eval()
+
 
     def objective(config):
         model.select_sub_network(config)
@@ -83,6 +84,7 @@ if __name__ == "__main__":
         model.reset_super_network()
 
         return mac, loss
+
 
     results = multi_objective_search(
         objective,

--- a/examples/sinc/search.py
+++ b/examples/sinc/search.py
@@ -5,11 +5,12 @@ import matplotlib.pyplot as plt
 import numpy as np
 import torch
 from estimate_efficiency import compute_mac_linear_layer
-from lobotomy.search import multi_objective_search
 from model import MLP
 from sinc_nas import f, validate
 from syne_tune.config_space import randint
 from torch.utils.data import DataLoader
+
+from lobotomy.search import multi_objective_search
 
 if __name__ == "__main__":
     parser = ArgumentParser()
@@ -55,14 +56,13 @@ if __name__ == "__main__":
     model = MLP(input_dim=1, hidden_dim=args.hidden_dim, device=device)
 
     path = (
-            Path(args.st_checkpoint_dir)
-            / f"{args.training_strategy}_model_{args.hidden_dim}.pt"
+        Path(args.st_checkpoint_dir)
+        / f"{args.training_strategy}_model_{args.hidden_dim}.pt"
     )
     checkpoint = torch.load(path)
     model.load_state_dict(checkpoint["state"])
     model = model.to(device)
     model.eval()
-
 
     def objective(config):
         model.select_sub_network(config)
@@ -83,7 +83,6 @@ if __name__ == "__main__":
         model.reset_super_network()
 
         return mac, loss
-
 
     results = multi_objective_search(
         objective,

--- a/examples/sinc/search.py
+++ b/examples/sinc/search.py
@@ -1,18 +1,16 @@
-import numpy as np
-import torch
-import matplotlib.pyplot as plt
-
 from argparse import ArgumentParser
 from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+from lobotomy.search import multi_objective_search
+from syne_tune.config_space import randint
 from torch.utils.data import DataLoader
 
-from syne_tune.config_space import randint
-from lobotomy.search import multi_objective_search
 from examples.sinc.estimate_efficiency import compute_mac_linear_layer
-
-from sinc_nas import validate, f
-from model import MLP
-
+from examples.sinc.model import MLP
+from examples.sinc.sinc_nas import f, validate
 
 if __name__ == "__main__":
     parser = ArgumentParser()
@@ -20,10 +18,16 @@ if __name__ == "__main__":
     parser.add_argument("--learning_rate", type=float, default=1e-3)
     parser.add_argument("--epochs", type=int, default=10)
     parser.add_argument("--hidden_dim", type=int, default=128)
-    parser.add_argument("--training_strategy", type=str, default="sandwich")
-    parser.add_argument("--search_strategy", type=str, default="random_search")
+    parser.add_argument(
+        "--training_strategy", type=str, default="sandwich"
+    )
+    parser.add_argument(
+        "--search_strategy", type=str, default="random_search"
+    )
     parser.add_argument("--do_plot", type=bool, default=False)
-    parser.add_argument("--st_checkpoint_dir", type=str, default="./checkpoints")
+    parser.add_argument(
+        "--st_checkpoint_dir", type=str, default="./checkpoints"
+    )
 
     args, _ = parser.parse_known_args()
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
@@ -42,8 +46,12 @@ if __name__ == "__main__":
     train_data = data[:n_train]
     valid_data = data[n_train:]
 
-    train_dataloader = DataLoader(train_data, batch_size=args.batch_size, shuffle=True)
-    valid_dataloader = DataLoader(valid_data, batch_size=args.batch_size, shuffle=False)
+    train_dataloader = DataLoader(
+        train_data, batch_size=args.batch_size, shuffle=True
+    )
+    valid_dataloader = DataLoader(
+        valid_data, batch_size=args.batch_size, shuffle=False
+    )
 
     model = MLP(input_dim=1, hidden_dim=args.hidden_dim, device=device)
 
@@ -68,7 +76,8 @@ if __name__ == "__main__":
             model.hidden_layer.in_features, config["num_units"]
         )
         mac += compute_mac_linear_layer(
-            model.output_layer.in_features, model.output_layer.out_features
+            model.output_layer.in_features,
+            model.output_layer.out_features,
         )
 
         model.reset_super_network()
@@ -85,11 +94,18 @@ if __name__ == "__main__":
     )
 
     costs = np.array(results["costs"])
-    plt.scatter(costs[:, 0], costs[:, 1], color="black", label="sub-networks")
+    plt.scatter(
+        costs[:, 0], costs[:, 1], color="black", label="sub-networks"
+    )
 
     idx = np.array(results["is_pareto_optimal"])
     if args.do_plot:
-        plt.scatter(costs[idx, 0], costs[idx, 1], color="red", label="Pareto optimal")
+        plt.scatter(
+            costs[idx, 0],
+            costs[idx, 1],
+            color="red",
+            label="Pareto optimal",
+        )
 
         plt.xlabel("mac")
         plt.ylabel("Validation loss")

--- a/examples/sinc/sinc_nas.py
+++ b/examples/sinc/sinc_nas.py
@@ -6,12 +6,13 @@ from pathlib import Path
 import numpy as np
 import torch
 import torch.nn as nn
-from lobotomy.sampling.random_sampler import RandomSampler
-from lobotomy.training_strategies import SandwichStrategy
 from model import MLP
 from syne_tune.config_space import randint
 from syne_tune.report import Reporter
 from torch.utils.data import DataLoader
+
+from lobotomy.sampling.random_sampler import RandomSampler
+from lobotomy.training_strategies import SandwichStrategy
 
 report = Reporter()
 

--- a/examples/sinc/sinc_nas.py
+++ b/examples/sinc/sinc_nas.py
@@ -1,19 +1,18 @@
-import os
-
-import numpy as np
 import json
-import torch
-import torch.nn as nn
-
+import os
 from argparse import ArgumentParser
 from pathlib import Path
-from torch.utils.data import DataLoader
+
+import numpy as np
+import torch
+import torch.nn as nn
+from lobotomy.sampling.random_sampler import RandomSampler
+from lobotomy.training_strategies import SandwichStrategy
 from syne_tune.config_space import randint
 from syne_tune.report import Reporter
-from lobotomy.training_strategies import SandwichStrategy
-from lobotomy.sampling.random_sampler import RandomSampler
+from torch.utils.data import DataLoader
 
-from model import MLP
+from examples.sinc.model import MLP
 
 report = Reporter()
 
@@ -47,9 +46,13 @@ if __name__ == "__main__":
     parser.add_argument("--learning_rate", type=float, default=1e-3)
     parser.add_argument("--epochs", type=int, default=10)
     parser.add_argument("--hidden_dim", type=int, default=128)
-    parser.add_argument("--training_strategy", type=str, default="sandwich")
+    parser.add_argument(
+        "--training_strategy", type=str, default="sandwich"
+    )
     parser.add_argument("--do_plot", type=bool, default=False)
-    parser.add_argument("--st_checkpoint_dir", type=str, default="./checkpoints")
+    parser.add_argument(
+        "--st_checkpoint_dir", type=str, default="./checkpoints"
+    )
     parser.add_argument("--seed", type=int, default=42)
 
     args, _ = parser.parse_known_args()
@@ -73,14 +76,26 @@ if __name__ == "__main__":
     train_data = data[:n_train]
     valid_data = data[n_train:]
 
-    train_dataloader = DataLoader(train_data, batch_size=args.batch_size, shuffle=True)
-    valid_dataloader = DataLoader(valid_data, batch_size=args.batch_size, shuffle=False)
+    train_dataloader = DataLoader(
+        train_data, batch_size=args.batch_size, shuffle=True
+    )
+    valid_dataloader = DataLoader(
+        valid_data, batch_size=args.batch_size, shuffle=False
+    )
 
-    model = MLP(input_dim=1, hidden_dim=args.hidden_dim, device=device).to(device)
-    n_params = sum(p.numel() for p in model.parameters() if p.requires_grad)
+    model = MLP(
+        input_dim=1, hidden_dim=args.hidden_dim, device=device
+    ).to(device)
+    n_params = sum(
+        p.numel() for p in model.parameters() if p.requires_grad
+    )
 
-    optimizer = torch.optim.Adam(model.parameters(), lr=args.learning_rate)
-    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=args.epochs)
+    optimizer = torch.optim.Adam(
+        model.parameters(), lr=args.learning_rate
+    )
+    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
+        optimizer, T_max=args.epochs
+    )
     current_best = None
     # if args.st_checkpoint_dir is not None:
     #     os.makedirs(args.st_checkpoint_dir, exist_ok=True)

--- a/examples/sinc/sinc_nas.py
+++ b/examples/sinc/sinc_nas.py
@@ -8,11 +8,10 @@ import torch
 import torch.nn as nn
 from lobotomy.sampling.random_sampler import RandomSampler
 from lobotomy.training_strategies import SandwichStrategy
+from model import MLP
 from syne_tune.config_space import randint
 from syne_tune.report import Reporter
 from torch.utils.data import DataLoader
-
-from .model import MLP
 
 report = Reporter()
 

--- a/examples/sinc/sinc_nas.py
+++ b/examples/sinc/sinc_nas.py
@@ -12,7 +12,7 @@ from syne_tune.config_space import randint
 from syne_tune.report import Reporter
 from torch.utils.data import DataLoader
 
-from examples.sinc.model import MLP
+from .model import MLP
 
 report = Reporter()
 

--- a/lobotomy/extract_subnetworks.py
+++ b/lobotomy/extract_subnetworks.py
@@ -1,8 +1,8 @@
 from collections import OrderedDict
+from copy import deepcopy
 
 import torch
 import torch.nn as nn
-from copy import deepcopy
 
 
 class IdentityAttention(nn.Module):
@@ -40,7 +40,9 @@ def get_final_model(original_model, architecture_definition):
 
     for i in range(new_model.config.num_hidden_layers):
         if architecture_definition[f"layer_mha_{i}"] == 0:
-            new_model.bert.encoder.layer[i].attention = IdentityAttention()
+            new_model.bert.encoder.layer[
+                i
+            ].attention = IdentityAttention()
         if architecture_definition[f"layer_ffn_{i}"] == 0:
             new_model.bert.encoder.layer[i].intermediate = IdentityFFN()
             new_model.bert.encoder.layer[i].output = IdentityOutput()
@@ -51,7 +53,9 @@ def get_final_model(original_model, architecture_definition):
 def copy_linear_layer(new_layer, old_layer, weight_shape, bias_shape):
     old_state = old_layer.state_dict()
     new_state_dict = OrderedDict()
-    new_state_dict["weight"] = old_state["weight"][: weight_shape[0], : weight_shape[1]]
+    new_state_dict["weight"] = old_state["weight"][
+        : weight_shape[0], : weight_shape[1]
+    ]
     new_state_dict["bias"] = old_state["bias"][:bias_shape]
     new_layer.load_state_dict(new_state_dict)
 
@@ -66,29 +70,45 @@ def copy_layer_norm(new_layer, old_layer):
 
 def get_final_bert_model(original_model, new_model_config):
     original_model.eval()
-    new_model = AutoModelForSequenceClassification.from_config(new_model_config)
+    new_model = AutoModelForSequenceClassification.from_config(
+        new_model_config
+    )
     new_model.eval()
 
     new_model.bert.embeddings.load_state_dict(
         original_model.bert.embeddings.state_dict()
     )
-    new_model.bert.pooler.load_state_dict(original_model.bert.pooler.state_dict())
-    new_model.classifier.load_state_dict(original_model.classifier.state_dict())
+    new_model.bert.pooler.load_state_dict(
+        original_model.bert.pooler.state_dict()
+    )
+    new_model.classifier.load_state_dict(
+        original_model.classifier.state_dict()
+    )
 
     num_attention_heads = new_model_config.num_attention_heads
     attention_head_size = new_model_config.attention_head_size
     all_head_size = num_attention_heads * attention_head_size
     for li, layer in enumerate(new_model.bert.encoder.layer):
         attention = layer.attention
-        attention.self.query = nn.Linear(new_model_config.hidden_size, all_head_size)
-        attention.self.key = nn.Linear(new_model_config.hidden_size, all_head_size)
-        attention.self.value = nn.Linear(new_model_config.hidden_size, all_head_size)
-        attention.output.dense = nn.Linear(all_head_size, new_model_config.hidden_size)
+        attention.self.query = nn.Linear(
+            new_model_config.hidden_size, all_head_size
+        )
+        attention.self.key = nn.Linear(
+            new_model_config.hidden_size, all_head_size
+        )
+        attention.self.value = nn.Linear(
+            new_model_config.hidden_size, all_head_size
+        )
+        attention.output.dense = nn.Linear(
+            all_head_size, new_model_config.hidden_size
+        )
 
         attention.self.all_head_size = all_head_size
         attention.self.attention_head_size = attention_head_size
 
-        mha_original_model = original_model.bert.encoder.layer[li].attention
+        mha_original_model = original_model.bert.encoder.layer[
+            li
+        ].attention
         copy_linear_layer(
             attention.self.query,
             mha_original_model.self.query,
@@ -117,23 +137,36 @@ def get_final_bert_model(original_model, new_model_config):
             (new_model_config.hidden_size),
         )
 
-        copy_layer_norm(attention.output.LayerNorm, mha_original_model.output.LayerNorm)
+        copy_layer_norm(
+            attention.output.LayerNorm,
+            mha_original_model.output.LayerNorm,
+        )
 
         ffn_layer = layer.intermediate.dense
-        ffn_original_model = original_model.bert.encoder.layer[li].intermediate.dense
+        ffn_original_model = original_model.bert.encoder.layer[
+            li
+        ].intermediate.dense
         copy_linear_layer(
             ffn_layer,
             ffn_original_model,
-            (new_model_config.intermediate_size, new_model_config.hidden_size),
+            (
+                new_model_config.intermediate_size,
+                new_model_config.hidden_size,
+            ),
             (new_model_config.intermediate_size),
         )
 
         ffn_layer = layer.output.dense
-        ffn_original_model = original_model.bert.encoder.layer[li].output.dense
+        ffn_original_model = original_model.bert.encoder.layer[
+            li
+        ].output.dense
         copy_linear_layer(
             ffn_layer,
             ffn_original_model,
-            (new_model_config.hidden_size, new_model_config.intermediate_size),
+            (
+                new_model_config.hidden_size,
+                new_model_config.intermediate_size,
+            ),
             (new_model_config.hidden_size),
         )
 
@@ -146,9 +179,12 @@ def get_final_bert_model(original_model, new_model_config):
 
 
 if __name__ == "__main__":
-    from transformers import AutoModelForSequenceClassification, AutoTokenizer
-    from transformers.models.bert.modeling_bert import BertConfig
     from benchmarks.plm_pruning.mask import mask_bert
+    from transformers import (
+        AutoModelForSequenceClassification,
+        AutoTokenizer,
+    )
+    from transformers.models.bert.modeling_bert import BertConfig
 
     model_type = "bert-base-uncased"
     model = AutoModelForSequenceClassification.from_pretrained(model_type)
@@ -170,7 +206,9 @@ if __name__ == "__main__":
         config.hidden_size / model.config.num_attention_heads
     )
 
-    new_model = get_final_bert_model(original_model=model, new_model_config=config)
+    new_model = get_final_bert_model(
+        original_model=model, new_model_config=config
+    )
 
     tokenizer = AutoTokenizer.from_pretrained(model_type)
 
@@ -183,14 +221,20 @@ if __name__ == "__main__":
     input = tokenizer(prompt, return_tensors="pt")
 
     handles = mask_bert(model, ffn_mask, head_mask)
-    output = model(**input, head_mask=head_mask, output_hidden_states=True)
+    output = model(
+        **input, head_mask=head_mask, output_hidden_states=True
+    )
 
     print(output.logits)
-    n_params = sum(p.numel() for p in model.parameters() if p.requires_grad)
+    n_params = sum(
+        p.numel() for p in model.parameters() if p.requires_grad
+    )
     print(n_params)
     for handle in handles:
         handle.remove()
     output_2 = new_model(**input, output_hidden_states=True)
     print(output_2.logits)
-    n_params = sum(p.numel() for p in new_model.parameters() if p.requires_grad)
+    n_params = sum(
+        p.numel() for p in new_model.parameters() if p.requires_grad
+    )
     print(n_params)

--- a/lobotomy/loss/kd_loss.py
+++ b/lobotomy/loss/kd_loss.py
@@ -1,5 +1,5 @@
-from torch import nn
 import torch.nn.functional as F
+from torch import nn
 
 
 class DistillLoss(nn.Module):
@@ -54,10 +54,13 @@ class DistillLoss(nn.Module):
                 F.softmax(outputs_teacher / self.temperature, dim=1),
             ) * (self.temperature**2)
 
-        hard_target_loss = F.cross_entropy(outputs, labels, reduction="mean")
+        hard_target_loss = F.cross_entropy(
+            outputs, labels, reduction="mean"
+        )
 
-        total_loss = soft_target_loss * self.distillation_weight + hard_target_loss * (
-            1 - self.distillation_weight
+        total_loss = (
+            soft_target_loss * self.distillation_weight
+            + hard_target_loss * (1 - self.distillation_weight)
         )
 
         return total_loss

--- a/lobotomy/models/gpt/__init__.py
+++ b/lobotomy/models/gpt/__init__.py
@@ -1,12 +1,12 @@
 # Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
 
-import re
 import logging
-
-from lobotomy.models.gpt.model import GPT
-from litgpt import Config
+import re
 
 from lightning_utilities.core.imports import RequirementCache
+from litgpt import Config
+
+from lobotomy.models.gpt.model import GPT
 
 _LIGHTNING_AVAILABLE = RequirementCache("lightning>=2.2.0.dev0")
 if not bool(_LIGHTNING_AVAILABLE):

--- a/lobotomy/models/gpt/blocks/__init__.py
+++ b/lobotomy/models/gpt/blocks/__init__.py
@@ -1,5 +1,11 @@
 from .causal_self_attention import CausalSelfAttention
-from .mlp import GptNeoxMLP, LLaMAMLP, GemmaMLP
+from .mlp import GemmaMLP, GptNeoxMLP, LLaMAMLP
 from .transformer_block import Block
 
-__all__ = ["CausalSelfAttention", "GptNeoxMLP", "LLaMAMLP", "GemmaMLP", "Block"]
+__all__ = [
+    "CausalSelfAttention",
+    "GptNeoxMLP",
+    "LLaMAMLP",
+    "GemmaMLP",
+    "Block",
+]

--- a/lobotomy/models/gpt/blocks/mlp.py
+++ b/lobotomy/models/gpt/blocks/mlp.py
@@ -1,16 +1,21 @@
 from typing import Optional
 
-import torch
 import litgpt
+import torch
 from litgpt import Config
+
 from lobotomy.modules import Linear
 
 
 class GptNeoxMLP(litgpt.model.GptNeoxMLP):
     def __init__(self, config: Config) -> None:
         super().__init__(config)
-        self.fc = Linear(config.n_embd, config.intermediate_size, bias=config.bias)
-        self.proj = Linear(config.intermediate_size, config.n_embd, bias=config.bias)
+        self.fc = Linear(
+            config.n_embd, config.intermediate_size, bias=config.bias
+        )
+        self.proj = Linear(
+            config.intermediate_size, config.n_embd, bias=config.bias
+        )
         self.config = config
         self.in_features = config.n_embd
         self.intermediate_size = config.intermediate_size
@@ -50,9 +55,15 @@ class GptNeoxMLP(litgpt.model.GptNeoxMLP):
 class LLaMAMLP(litgpt.model.LLaMAMLP):
     def __init__(self, config: Config) -> None:
         super().__init__(config)
-        self.fc_1 = Linear(config.n_embd, config.intermediate_size, bias=config.bias)
-        self.fc_2 = Linear(config.n_embd, config.intermediate_size, bias=config.bias)
-        self.proj = Linear(config.intermediate_size, config.n_embd, bias=config.bias)
+        self.fc_1 = Linear(
+            config.n_embd, config.intermediate_size, bias=config.bias
+        )
+        self.fc_2 = Linear(
+            config.n_embd, config.intermediate_size, bias=config.bias
+        )
+        self.proj = Linear(
+            config.intermediate_size, config.n_embd, bias=config.bias
+        )
         self.in_features = config.n_embd
         self.intermediate_size = config.intermediate_size
         self.sub_network_n_embd: Optional[int] = None
@@ -101,7 +112,9 @@ class GemmaMLP(LLaMAMLP):
         x_fc_1 = self.fc_1(x)
         x_fc_2 = self.fc_2(x)
         x = (
-            torch.nn.functional.gelu(x_fc_1, approximate=self.config.gelu_approximate)
+            torch.nn.functional.gelu(
+                x_fc_1, approximate=self.config.gelu_approximate
+            )
             * x_fc_2
         )
         return self.proj(x)

--- a/lobotomy/models/gpt/extract.py
+++ b/lobotomy/models/gpt/extract.py
@@ -43,7 +43,9 @@ def extract_linear(super_network_linear):
     ]
 
     if super_network_linear.use_bias:
-        new_state_dict["bias"] = super_network_state["bias"][:out_feat_sub]
+        new_state_dict["bias"] = super_network_state["bias"][
+            :out_feat_sub
+        ]
 
     return new_state_dict
 
@@ -51,7 +53,9 @@ def extract_linear(super_network_linear):
 def extract_embedding(super_network_embedding):
     super_network_state = super_network_embedding.state_dict()
     new_state_dict = OrderedDict()
-    sub_network_embedding_dim = super_network_embedding.sub_network_embedding_dim
+    sub_network_embedding_dim = (
+        super_network_embedding.sub_network_embedding_dim
+    )
 
     new_state_dict["weight"] = super_network_state["weight"][
         :, :sub_network_embedding_dim

--- a/lobotomy/models/gpt/model.py
+++ b/lobotomy/models/gpt/model.py
@@ -5,12 +5,12 @@ https://github.com/EleutherAI/gpt-neox/tree/main/megatron/model.
 """
 
 from typing import Any, Optional, Tuple
+from typing_extensions import Self
 
 import torch
 import torch.nn as nn
 from litgpt import Config
 from litgpt.model import build_rope_cache
-from typing_extensions import Self
 
 from lobotomy.models.gpt.blocks import Block
 from lobotomy.modules.embedding import Embedding

--- a/lobotomy/models/gpt/utils.py
+++ b/lobotomy/models/gpt/utils.py
@@ -20,6 +20,7 @@ from typing import (
     TypeVar,
     Union,
 )
+from typing_extensions import Self
 
 import lightning as L
 import numpy as np
@@ -29,7 +30,6 @@ import torch.utils._device
 from lightning.fabric.strategies import FSDPStrategy
 from lightning.fabric.utilities.load import _lazy_load as lazy_load
 from torch.serialization import normalize_storage_type
-from typing_extensions import Self
 
 if TYPE_CHECKING:
     from gpt.model import GPT

--- a/lobotomy/modules/embedding.py
+++ b/lobotomy/modules/embedding.py
@@ -1,7 +1,7 @@
+from typing import Optional
+
 import torch
 import torch.nn.functional as F
-
-from typing import Optional
 
 
 class Embedding(torch.nn.Embedding):
@@ -34,7 +34,9 @@ class Embedding(torch.nn.Embedding):
         self.random_indices = torch.arange(self.sub_network_embedding_dim)
 
     def set_sub_network(
-        self, sub_network_embedding_dim: int, sample_random_indices: bool = False
+        self,
+        sub_network_embedding_dim: int,
+        sample_random_indices: bool = False,
     ):
         self.sub_network_embedding_dim = sub_network_embedding_dim
         self.random_indices = torch.arange(self.sub_network_embedding_dim)

--- a/lobotomy/modules/layernorm.py
+++ b/lobotomy/modules/layernorm.py
@@ -12,11 +12,16 @@ class LayerNorm(torch.nn.LayerNorm):
         self.random_indices = torch.arange(self.sub_network_in_features)
 
     def set_sub_network(
-        self, sub_network_in_features: int, sample_random_indices: bool = False
+        self,
+        sub_network_in_features: int,
+        sample_random_indices: bool = False,
     ):
         self.sub_network_in_features = sub_network_in_features
         self.random_indices = torch.arange(self.sub_network_in_features)
-        if sample_random_indices and self.sub_network_in_features < self.in_features:
+        if (
+            sample_random_indices
+            and self.sub_network_in_features < self.in_features
+        ):
             self.random_indices = torch.randperm(self.in_features)[
                 : self.sub_network_in_features
             ]

--- a/lobotomy/modules/linear.py
+++ b/lobotomy/modules/linear.py
@@ -19,8 +19,12 @@ class Linear(nn.Linear):
         self.sub_network_in_features = in_features
         self.sub_network_out_features = out_features
         self.use_bias = bias
-        self.random_indices_in_features = torch.arange(self.sub_network_in_features)
-        self.random_indices_out_features = torch.arange(self.sub_network_out_features)
+        self.random_indices_in_features = torch.arange(
+            self.sub_network_in_features
+        )
+        self.random_indices_out_features = torch.arange(
+            self.sub_network_out_features
+        )
 
     def set_sub_network(
         self,
@@ -30,22 +34,36 @@ class Linear(nn.Linear):
     ):
         self.sub_network_in_features = sub_network_in_features
         self.sub_network_out_features = sub_network_out_features
-        self.random_indices_in_features = torch.arange(self.sub_network_in_features)
-        self.random_indices_out_features = torch.arange(self.sub_network_out_features)
-        if sample_random_indices and self.sub_network_in_features < self.in_features:
-            self.random_indices_in_features = torch.randperm(self.in_features)[
-                : self.sub_network_in_features
-            ]
-        if sample_random_indices and self.sub_network_out_features < self.out_features:
-            self.random_indices_out_features = torch.randperm(self.out_features)[
-                : self.sub_network_out_features
-            ]
+        self.random_indices_in_features = torch.arange(
+            self.sub_network_in_features
+        )
+        self.random_indices_out_features = torch.arange(
+            self.sub_network_out_features
+        )
+        if (
+            sample_random_indices
+            and self.sub_network_in_features < self.in_features
+        ):
+            self.random_indices_in_features = torch.randperm(
+                self.in_features
+            )[: self.sub_network_in_features]
+        if (
+            sample_random_indices
+            and self.sub_network_out_features < self.out_features
+        ):
+            self.random_indices_out_features = torch.randperm(
+                self.out_features
+            )[: self.sub_network_out_features]
 
     def reset_super_network(self):
         self.sub_network_in_features = self.in_features
         self.sub_network_out_features = self.out_features
-        self.random_indices_in_features = torch.arange(self.sub_network_in_features)
-        self.random_indices_out_features = torch.arange(self.sub_network_out_features)
+        self.random_indices_in_features = torch.arange(
+            self.sub_network_in_features
+        )
+        self.random_indices_out_features = torch.arange(
+            self.sub_network_out_features
+        )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         if self.use_bias:

--- a/lobotomy/modules/rmsnorm.py
+++ b/lobotomy/modules/rmsnorm.py
@@ -33,7 +33,10 @@ class RMSNorm(torch.nn.Module):
     ):
         self.sub_network_in_features = sub_network_in_features
         self.random_indices = torch.arange(self.sub_network_in_features)
-        if sample_random_indices and self.sub_network_in_features < self.in_features:
+        if (
+            sample_random_indices
+            and self.sub_network_in_features < self.in_features
+        ):
             self.random_indices = torch.randperm(self.in_features)[
                 : self.sub_network_in_features
             ]
@@ -53,7 +56,9 @@ class RMSNorm(torch.nn.Module):
         x_normed = x * torch.rsqrt(norm_x + self.eps)
         if self.add_unit_offset:
             return x_normed * (1.0 + self.weight[self.random_indices])
-        return (self.weight[self.random_indices] * x_normed).to(dtype=dtype)
+        return (self.weight[self.random_indices] * x_normed).to(
+            dtype=dtype
+        )
 
     def reset_parameters(self) -> None:
         torch.nn.init.ones_(self.weight)

--- a/lobotomy/sampling/random_sampler.py
+++ b/lobotomy/sampling/random_sampler.py
@@ -1,8 +1,7 @@
 from typing import Dict, Optional
 
 import numpy as np
-
-from syne_tune.config_space import Domain, Categorical
+from syne_tune.config_space import Categorical, Domain
 
 
 class RandomSampler(object):

--- a/lobotomy/search/ask_tell_scheduler.py
+++ b/lobotomy/search/ask_tell_scheduler.py
@@ -1,7 +1,7 @@
-from typing import Dict
 import datetime
+from typing import Dict
 
-from syne_tune.backend.trial_status import Trial, Status, TrialResult
+from syne_tune.backend.trial_status import Status, Trial, TrialResult
 from syne_tune.optimizer.scheduler import TrialScheduler
 
 
@@ -41,7 +41,9 @@ class AskTellScheduler:
             status=Status.completed,
             training_end_time=datetime.datetime.now(),
         )
-        self.bscheduler.on_trial_complete(trial=trial, result=experiment_result)
+        self.bscheduler.on_trial_complete(
+            trial=trial, result=experiment_result
+        )
         self.completed_experiments[trial_result.trial_id] = trial_result
 
     def best_trial(self, metris: str) -> TrialResult:

--- a/lobotomy/search/baselines.py
+++ b/lobotomy/search/baselines.py
@@ -1,15 +1,15 @@
 from dataclasses import dataclass
 from typing import Dict
 
-from syne_tune.config_space import Domain, Categorical
+from syne_tune.config_space import Categorical, Domain
 from syne_tune.optimizer.baselines import (
-    RandomSearch,
     MOREA,
     NSGA2,
     MORandomScalarizationBayesOpt,
-    # EHVI
+    RandomSearch,
 )
 
+# EHVI
 from syne_tune.optimizer.schedulers.multiobjective.linear_scalarizer import (
     LinearScalarizedScheduler,
 )

--- a/lobotomy/search/local_search.py
+++ b/lobotomy/search/local_search.py
@@ -1,13 +1,12 @@
-import numpy as np
 import logging
 from copy import deepcopy
-from typing import Optional, List, Dict, Any, Union
 from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Union
 
+import numpy as np
+from syne_tune.config_space import Domain
 from syne_tune.optimizer.schedulers import FIFOScheduler
 from syne_tune.optimizer.schedulers.searchers import StochasticSearcher
-from syne_tune.config_space import Domain
-
 
 logger = logging.getLogger(__name__)
 
@@ -111,9 +110,13 @@ class LocalSearch(StochasticSearcher):
             }
         else:
             if self._mode == "min":
-                self._metric_op = dict(zip(self._metric, [1.0] * len(self._metric)))
+                self._metric_op = dict(
+                    zip(self._metric, [1.0] * len(self._metric))
+                )
             elif self._mode == "max":
-                self._metric_op = dict(zip(self._metric, [-1.0] * len(self._metric)))
+                self._metric_op = dict(
+                    zip(self._metric, [-1.0] * len(self._metric))
+                )
 
     def _sample_random_neighbour(self, start_point):
         # get actual hyperparameters from the search space
@@ -144,14 +147,16 @@ class LocalSearch(StochasticSearcher):
     def is_efficient(self, costs):
         is_efficient = np.ones(costs.shape[0], dtype=bool)
         for i, c in enumerate(costs):
-            is_efficient[i] = np.all(np.any(costs[:i] > c, axis=1)) and np.all(
-                np.any(costs[i + 1 :] > c, axis=1)
-            )
+            is_efficient[i] = np.all(
+                np.any(costs[:i] > c, axis=1)
+            ) and np.all(np.any(costs[i + 1 :] > c, axis=1))
 
         return is_efficient
 
     def dominates(self, incumbent, neighbour):
-        return np.all(neighbour <= incumbent) * np.any(neighbour < incumbent)
+        return np.all(neighbour <= incumbent) * np.any(
+            neighbour < incumbent
+        )
 
     def get_config(self, **kwargs) -> Optional[dict]:
         config = self._next_initial_config()
@@ -173,10 +178,17 @@ class LocalSearch(StochasticSearcher):
             for metric in self._metric
         }
 
-    def _update(self, trial_id: int, config: Dict[str, Any], result: Dict[str, Any]):
+    def _update(
+        self,
+        trial_id: int,
+        config: Dict[str, Any],
+        result: Dict[str, Any],
+    ):
         # assume that the new point is in the Pareto Front
         element = PopulationElement(
-            trial_id=trial_id, config=config, result=self._metric_dict(result)
+            trial_id=trial_id,
+            config=config,
+            result=self._metric_dict(result),
         )
 
         if len(self._pareto_front) == 0:
@@ -186,7 +198,10 @@ class LocalSearch(StochasticSearcher):
         pareto_front = deepcopy(self._pareto_front)
         pareto_front.append(element)
         costs = np.array(
-            [[v for v in element.result.values()] for element in pareto_front]
+            [
+                [v for v in element.result.values()]
+                for element in pareto_front
+            ]
         )
 
         # check for Pareto efficiency
@@ -212,11 +227,10 @@ class LocalSearch(StochasticSearcher):
 
 
 if __name__ == "__main__":
-    from transformers import AutoConfig
-
     from nas_fine_tuning.sampling import SmallSearchSpace
-    from syne_tune.tuner import Trial
     from syne_tune.config_space import Categorical
+    from syne_tune.tuner import Trial
+    from transformers import AutoConfig
 
     config = AutoConfig.from_pretrained("bert-base-cased")
     ss = SmallSearchSpace(config)
@@ -249,5 +263,6 @@ if __name__ == "__main__":
         # ls._update(trial_id=i, config=config, result={'a': np.random.rand(), 'b':np.random.rand()})
         result = {"a": np.random.rand(), "b": np.random.rand()}
         ls.on_trial_result(
-            Trial(trial_id=i, config=trial.config, creation_time=None), result=result
+            Trial(trial_id=i, config=trial.config, creation_time=None),
+            result=result,
         )

--- a/lobotomy/search/multi_objective.py
+++ b/lobotomy/search/multi_objective.py
@@ -16,7 +16,9 @@ def get_pareto_optimal(costs: np.ndarray):
         if is_pareto[i]:
             # determine all points that have a smaller cost
             all_with_lower_costs = np.any(costs < c, axis=1)
-            keep_on_front = np.logical_and(all_with_lower_costs, is_pareto)
+            keep_on_front = np.logical_and(
+                all_with_lower_costs, is_pareto
+            )
             is_pareto = keep_on_front
             is_pareto[i] = True  # keep self
     return is_pareto

--- a/lobotomy/search/search.py
+++ b/lobotomy/search/search.py
@@ -3,8 +3,8 @@ from typing import Optional
 
 import numpy as np
 
-from lobotomy.search.baselines import MethodArguments, methods
 from lobotomy.search.ask_tell_scheduler import AskTellScheduler
+from lobotomy.search.baselines import MethodArguments, methods
 from lobotomy.search.multi_objective import get_pareto_optimal
 
 
@@ -56,7 +56,8 @@ def multi_objective_search(
         )
 
         scheduler.tell(
-            trial_suggestion, {"objective_1": objective_1, "objective_2": objective_2}
+            trial_suggestion,
+            {"objective_1": objective_1, "objective_2": objective_2},
         )
 
         # bookkeeping

--- a/lobotomy/training_strategies/__init__.py
+++ b/lobotomy/training_strategies/__init__.py
@@ -1,8 +1,8 @@
-from .sandwich import SandwichStrategy
-from .random import RandomStrategy
-from .standard import StandardStrategy
-from .random_linear import RandomLinearStrategy
 from .ats import ATS
+from .random import RandomStrategy
+from .random_linear import RandomLinearStrategy
+from .sandwich import SandwichStrategy
+from .standard import StandardStrategy
 
 __all__ = [
     "SandwichStrategy",

--- a/lobotomy/training_strategies/ats.py
+++ b/lobotomy/training_strategies/ats.py
@@ -1,4 +1,6 @@
-from lobotomy.training_strategies.base_strategy import BaseTrainingStrategy
+from lobotomy.training_strategies.base_strategy import (
+    BaseTrainingStrategy,
+)
 
 
 class ATS(BaseTrainingStrategy):

--- a/lobotomy/training_strategies/base_strategy.py
+++ b/lobotomy/training_strategies/base_strategy.py
@@ -1,7 +1,9 @@
-from lobotomy.sampling.random_sampler import RandomSampler
 from typing import Callable, Optional
-from lobotomy.loss import DistillLoss
+
 import torch
+
+from lobotomy.loss import DistillLoss
+from lobotomy.sampling.random_sampler import RandomSampler
 
 
 class BaseTrainingStrategy(object):

--- a/lobotomy/training_strategies/random.py
+++ b/lobotomy/training_strategies/random.py
@@ -1,4 +1,6 @@
-from lobotomy.training_strategies.base_strategy import BaseTrainingStrategy
+from lobotomy.training_strategies.base_strategy import (
+    BaseTrainingStrategy,
+)
 
 
 class RandomStrategy(BaseTrainingStrategy):

--- a/lobotomy/training_strategies/random_linear.py
+++ b/lobotomy/training_strategies/random_linear.py
@@ -1,6 +1,8 @@
 import numpy as np
 
-from lobotomy.training_strategies.base_strategy import BaseTrainingStrategy
+from lobotomy.training_strategies.base_strategy import (
+    BaseTrainingStrategy,
+)
 
 
 class RandomLinearStrategy(BaseTrainingStrategy):
@@ -8,7 +10,12 @@ class RandomLinearStrategy(BaseTrainingStrategy):
     Random linear strategy.
     """
 
-    def __init__(self, total_number_of_steps: int, random_samples: int = 1, **kwargs):
+    def __init__(
+        self,
+        total_number_of_steps: int,
+        random_samples: int = 1,
+        **kwargs,
+    ):
         super().__init__(**kwargs)
         self.random_samples = random_samples
         self.total_number_of_steps = total_number_of_steps

--- a/lobotomy/training_strategies/sandwich.py
+++ b/lobotomy/training_strategies/sandwich.py
@@ -1,4 +1,6 @@
-from lobotomy.training_strategies.base_strategy import BaseTrainingStrategy
+from lobotomy.training_strategies.base_strategy import (
+    BaseTrainingStrategy,
+)
 
 
 class SandwichStrategy(BaseTrainingStrategy):

--- a/lobotomy/training_strategies/standard.py
+++ b/lobotomy/training_strategies/standard.py
@@ -1,4 +1,6 @@
-from lobotomy.training_strategies.base_strategy import BaseTrainingStrategy
+from lobotomy.training_strategies.base_strategy import (
+    BaseTrainingStrategy,
+)
 
 
 class StandardStrategy(BaseTrainingStrategy):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,8 @@ exclude = [
 
 target-version = "py39"
 
+src = ["lobotomy", "tests", "benchmarks", "examples"]
+
 [tool.ruff.lint]
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,13 +64,17 @@ exclude = [
 
 target-version = "py39"
 
-src = ["lobotomy", "tests", "benchmarks", "examples"]
+src = ["lobotomy", "tests", "benchmarks", "examples", "sinc"]
+
+line-length = 74
+
 
 [tool.ruff.lint]
+#extend-select = ["I"]
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
 # McCabe complexity (`C901`) by default.
-select = ["E4", "E7", "E9", "F"]
+select = ["E4", "E7", "E9", "F", "I"]
 ignore = []
 
 # Allow fix for all enabled rules (when `--fix`) is provided.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,3 +103,7 @@ line-ending = "auto"
 # This is currently disabled by default, but it is planned for this
 # to be opt-out in the future.
 docstring-code-format = false
+
+[tool.ruff.lint.isort]
+known-first-party = ["lobotomy", "examples"]
+extra-standard-library = ["typing_extensions"]

--- a/test/test_attention.py
+++ b/test/test_attention.py
@@ -1,21 +1,27 @@
-import torch
-from lobotomy.models.gpt.blocks import CausalSelfAttention
-from litgpt.model import CausalSelfAttention as LitCausalSelfAttention
-from litgpt import Config
-from litgpt.model import build_mask_cache, build_rope_cache
 import pytest
+import torch
+from litgpt import Config
+from litgpt.model import CausalSelfAttention as LitCausalSelfAttention
+from litgpt.model import build_mask_cache, build_rope_cache
+from lobotomy.models.gpt.blocks import CausalSelfAttention
 
 attention_configs = {
     "mha_fix_head_size": {
-        "config": Config(n_embd=128, n_head=16, n_query_groups=16, head_size=64),
+        "config": Config(
+            n_embd=128, n_head=16, n_query_groups=16, head_size=64
+        ),
         "fix_head_size": True,
     },
     "gqa_fix_head_size": {
-        "config": Config(n_embd=128, n_head=16, n_query_groups=2, head_size=64),
+        "config": Config(
+            n_embd=128, n_head=16, n_query_groups=2, head_size=64
+        ),
         "fix_head_size": True,
     },
     "mqa_fix_head_size": {
-        "config": Config(n_embd=128, n_head=16, n_query_groups=1, head_size=64),
+        "config": Config(
+            n_embd=128, n_head=16, n_query_groups=1, head_size=64
+        ),
         "fix_head_size": True,
     },
     "mha_flexible_head_size": {
@@ -35,26 +41,36 @@ attention_configs = {
 
 def init_attention(config):
     attention = CausalSelfAttention(config)
-    attention.attn.weight.data = torch.ones_like(attention.attn.weight.data)
+    attention.attn.weight.data = torch.ones_like(
+        attention.attn.weight.data
+    )
     attention.attn.bias.data = torch.ones_like(attention.attn.bias.data)
     attention.proj.bias.data = torch.ones_like(attention.proj.bias.data)
-    attention.proj.weight.data = torch.ones_like(attention.proj.weight.data)
+    attention.proj.weight.data = torch.ones_like(
+        attention.proj.weight.data
+    )
     return attention
 
 
 def init_lit_attention(config):
     attention = LitCausalSelfAttention(config)
-    attention.attn.weight.data = torch.ones_like(attention.attn.weight.data)
+    attention.attn.weight.data = torch.ones_like(
+        attention.attn.weight.data
+    )
     attention.attn.bias.data = torch.ones_like(attention.attn.bias.data)
     attention.proj.bias.data = torch.ones_like(attention.proj.bias.data)
-    attention.proj.weight.data = torch.ones_like(attention.proj.weight.data)
+    attention.proj.weight.data = torch.ones_like(
+        attention.proj.weight.data
+    )
     return attention
 
 
 @pytest.mark.parametrize("attention_config", attention_configs.keys())
 def test_attention(attention_config):
     config = attention_configs[attention_config]["config"]
-    config.fix_head_size = attention_configs[attention_config]["fix_head_size"]
+    config.fix_head_size = attention_configs[attention_config][
+        "fix_head_size"
+    ]
     config.max_seq_len = 512
     config.rope_n_elem = int(config.rotary_percentage * config.head_size)
 
@@ -74,10 +90,14 @@ def test_attention(attention_config):
     out_lit_large = lit_attention(input, mask=mask, cos=cos, sin=sin)
 
     attention.set_sub_network(
-        sub_network_n_embd=config.n_embd // 2, sub_network_n_head=config.n_head // 4
+        sub_network_n_embd=config.n_embd // 2,
+        sub_network_n_head=config.n_head // 4,
     )
     cos, sin = build_rope_cache(
-        seq_len, n_elem=int(config.rotary_percentage * attention.sub_network_head_size)
+        seq_len,
+        n_elem=int(
+            config.rotary_percentage * attention.sub_network_head_size
+        ),
     )
     out_small = attention(
         input[:, :, : config.n_embd // 2], mask=mask, cos=cos, sin=sin

--- a/test/test_attention.py
+++ b/test/test_attention.py
@@ -3,6 +3,7 @@ import torch
 from litgpt import Config
 from litgpt.model import CausalSelfAttention as LitCausalSelfAttention
 from litgpt.model import build_mask_cache, build_rope_cache
+
 from lobotomy.models.gpt.blocks import CausalSelfAttention
 
 attention_configs = {

--- a/test/test_checkpoint_loading.py
+++ b/test/test_checkpoint_loading.py
@@ -5,6 +5,7 @@ import torch
 from litgpt import Config
 from litgpt.model import GPT as LitGPT
 from litgpt.scripts.download import download_from_hub
+
 from lobotomy.models.gpt.model import GPT as LobotomyGPT
 
 

--- a/test/test_checkpoint_loading.py
+++ b/test/test_checkpoint_loading.py
@@ -1,7 +1,7 @@
-import pytest
-import torch
 import pathlib
 
+import pytest
+import torch
 from litgpt import Config
 from litgpt.model import GPT as LitGPT
 from litgpt.scripts.download import download_from_hub
@@ -12,17 +12,23 @@ from lobotomy.models.gpt.model import GPT as LobotomyGPT
 def checkpoint_dir(tmp_path_factory):
     # img = compute_expensive_image()
     checkpoint_dir = tmp_path_factory.getbasetemp()
-    download_from_hub(repo_id="EleutherAI/pythia-70m", checkpoint_dir=checkpoint_dir)
+    download_from_hub(
+        repo_id="EleutherAI/pythia-70m", checkpoint_dir=checkpoint_dir
+    )
     return pathlib.Path(checkpoint_dir) / "EleutherAI" / "pythia-70m"
 
 
 def test_checkpoint_loading(checkpoint_dir):
     torch.manual_seed(0)
     config = Config.from_file(str(checkpoint_dir / "model_config.yaml"))
-    input_ids = torch.randint(0, config.vocab_size, (1, config.block_size))  # .cuda()
+    input_ids = torch.randint(
+        0, config.vocab_size, (1, config.block_size)
+    )  # .cuda()
 
     model = LitGPT(config)  # .cuda()
-    model.load_state_dict(torch.load(str(checkpoint_dir / "lit_model.pth")))
+    model.load_state_dict(
+        torch.load(str(checkpoint_dir / "lit_model.pth"))
+    )
     # test output
     model.eval()
     output_lit = model(input_ids)
@@ -32,10 +38,14 @@ def test_checkpoint_loading(checkpoint_dir):
     config = Config.from_file(str(checkpoint_dir / "model_config.yaml"))
     config.fix_head_size = False
     model = LobotomyGPT(config)  # .cuda()
-    model.load_state_dict(torch.load(str(checkpoint_dir / "lit_model.pth")))
+    model.load_state_dict(
+        torch.load(str(checkpoint_dir / "lit_model.pth"))
+    )
     # test output
     model.eval()
-    sample_intermediate_size = [4 * config.n_embd for i in range(config.n_layer)]
+    sample_intermediate_size = [
+        4 * config.n_embd for i in range(config.n_layer)
+    ]
     model.set_sub_network(
         config.n_embd,
         sample_intermediate_size,

--- a/test/test_embedding.py
+++ b/test/test_embedding.py
@@ -1,4 +1,5 @@
 import torch
+
 from lobotomy.modules.embedding import Embedding
 
 

--- a/test/test_embedding.py
+++ b/test/test_embedding.py
@@ -1,5 +1,4 @@
 import torch
-
 from lobotomy.modules.embedding import Embedding
 
 

--- a/test/test_extract.py
+++ b/test/test_extract.py
@@ -1,7 +1,5 @@
 import torch
-
 from litgpt.config import Config
-
 from lobotomy.models.gpt import GPT
 from lobotomy.models.gpt.extract import extract_sub_network
 
@@ -17,9 +15,12 @@ def test_extract_sub_network() -> None:
     super_network.eval()
     super_network.set_sub_network(
         sub_network_n_embd=sub_network_config.n_embd,
-        sub_network_intermediate_size=[sub_network_config.intermediate_size]
+        sub_network_intermediate_size=[
+            sub_network_config.intermediate_size
+        ]
         * sub_network_config.n_layer,
-        sub_network_num_heads=[sub_network_config.n_head] * sub_network_config.n_layer,
+        sub_network_num_heads=[sub_network_config.n_head]
+        * sub_network_config.n_layer,
         sub_network_n_layers=sub_network_config.n_layer,
     )
 
@@ -30,5 +31,6 @@ def test_extract_sub_network() -> None:
     out_super_net = super_network(input).detach()
     out_sub_net = sub_network(input).detach()
     assert torch.all(
-        torch.round(out_sub_net, decimals=9) == torch.round(out_super_net, decimals=9)
+        torch.round(out_sub_net, decimals=9)
+        == torch.round(out_super_net, decimals=9)
     )

--- a/test/test_extract.py
+++ b/test/test_extract.py
@@ -1,5 +1,6 @@
 import torch
 from litgpt.config import Config
+
 from lobotomy.models.gpt import GPT
 from lobotomy.models.gpt.extract import extract_sub_network
 

--- a/test/test_linear.py
+++ b/test/test_linear.py
@@ -1,4 +1,5 @@
 import torch
+
 from lobotomy.modules.linear import Linear
 
 

--- a/test/test_linear.py
+++ b/test/test_linear.py
@@ -8,21 +8,31 @@ def test_linear():
     linear.reset_super_network()
     out = linear(input_features)
     assert out.shape == (8, 32)
-    linear.set_sub_network(sub_network_in_features=64, sub_network_out_features=16)
+    linear.set_sub_network(
+        sub_network_in_features=64, sub_network_out_features=16
+    )
     out = linear(input_features)
     assert out.shape == (8, 16)
-    linear.set_sub_network(sub_network_in_features=64, sub_network_out_features=32)
+    linear.set_sub_network(
+        sub_network_in_features=64, sub_network_out_features=32
+    )
     out = linear(input_features)
     assert out.shape == (8, 32)
 
     input_small = torch.rand(8, 16)
     linear.weight.data = torch.ones_like(linear.weight.data)
     linear.bias.data = torch.ones_like(linear.bias.data)
-    linear.set_sub_network(sub_network_in_features=64, sub_network_out_features=16)
+    linear.set_sub_network(
+        sub_network_in_features=64, sub_network_out_features=16
+    )
     out_small = linear(input_features)
-    linear.set_sub_network(sub_network_in_features=64, sub_network_out_features=32)
+    linear.set_sub_network(
+        sub_network_in_features=64, sub_network_out_features=32
+    )
     out_large = linear(input_features)
-    linear.set_sub_network(sub_network_in_features=16, sub_network_out_features=32)
+    linear.set_sub_network(
+        sub_network_in_features=16, sub_network_out_features=32
+    )
     out_small_large = linear(input_small)
 
     small_layer = torch.nn.Linear(64, 16, bias=True)
@@ -37,8 +47,12 @@ def test_linear():
     out_large_layer = large_layer(input_features)
 
     small_large_layer = torch.nn.Linear(16, 32)
-    small_large_layer.weight.data = torch.ones_like(small_large_layer.weight.data)
-    small_large_layer.bias.data = torch.ones_like(small_large_layer.bias.data)
+    small_large_layer.weight.data = torch.ones_like(
+        small_large_layer.weight.data
+    )
+    small_large_layer.bias.data = torch.ones_like(
+        small_large_layer.bias.data
+    )
     out_small_large_layer = small_large_layer(input_small)
 
     assert torch.all(out_small == out_small_layer)

--- a/test/test_lmhead.py
+++ b/test/test_lmhead.py
@@ -9,22 +9,30 @@ def test_linear():
     out = linear(input_features)
     assert out.shape == (8, 10)
     input_features = torch.rand(8, 16)
-    linear.set_sub_network(sub_network_in_features=16, sub_network_out_features=10)
+    linear.set_sub_network(
+        sub_network_in_features=16, sub_network_out_features=10
+    )
     out = linear(input_features)
     assert out.shape == (8, 10)
 
-    linear.set_sub_network(sub_network_in_features=64, sub_network_out_features=10)
+    linear.set_sub_network(
+        sub_network_in_features=64, sub_network_out_features=10
+    )
     input_features = torch.rand(8, 64)
     out = linear(input_features)
     assert out.shape == (8, 10)
 
     linear.weight.data = torch.ones_like(linear.weight.data)
     linear.bias.data = torch.ones_like(linear.bias.data)
-    linear.set_sub_network(sub_network_in_features=16, sub_network_out_features=10)
+    linear.set_sub_network(
+        sub_network_in_features=16, sub_network_out_features=10
+    )
     input_features_small = torch.rand(8, 16)
     out_small = linear(input_features_small)
     input_features_large = torch.rand(8, 64)
-    linear.set_sub_network(sub_network_in_features=64, sub_network_out_features=10)
+    linear.set_sub_network(
+        sub_network_in_features=64, sub_network_out_features=10
+    )
     out_large = linear(input_features_large)
 
     small_layer = torch.nn.Linear(16, 10, bias=True)

--- a/test/test_lmhead.py
+++ b/test/test_lmhead.py
@@ -1,4 +1,5 @@
 import torch
+
 from lobotomy.modules.linear import Linear
 
 

--- a/test/test_mlp.py
+++ b/test/test_mlp.py
@@ -1,11 +1,15 @@
 import torch
-from lobotomy.models.gpt.blocks import GptNeoxMLP, LLaMAMLP, GemmaMLP
+from litgpt import Config
 from litgpt.model import (
-    GptNeoxMLP as LitGptNeoxMLP,
-    LLaMAMLP as LitLLaMAMLP,
     GemmaMLP as LitGemmaMLP,
 )
-from litgpt import Config
+from litgpt.model import (
+    GptNeoxMLP as LitGptNeoxMLP,
+)
+from litgpt.model import (
+    LLaMAMLP as LitLLaMAMLP,
+)
+from lobotomy.models.gpt.blocks import GemmaMLP, GptNeoxMLP, LLaMAMLP
 
 
 def test_GptNeoxMLP():
@@ -16,10 +20,16 @@ def test_GptNeoxMLP():
     config.intermediate_size = 64 * 4
     gpt_neox_mlp = GptNeoxMLP(config)
     # init weights and biases
-    gpt_neox_mlp.fc.weight.data = torch.ones_like(gpt_neox_mlp.fc.weight.data)
+    gpt_neox_mlp.fc.weight.data = torch.ones_like(
+        gpt_neox_mlp.fc.weight.data
+    )
     gpt_neox_mlp.fc.bias.data = torch.ones_like(gpt_neox_mlp.fc.bias.data)
-    gpt_neox_mlp.proj.weight.data = torch.ones_like(gpt_neox_mlp.proj.weight.data)
-    gpt_neox_mlp.proj.bias.data = torch.ones_like(gpt_neox_mlp.proj.bias.data)
+    gpt_neox_mlp.proj.weight.data = torch.ones_like(
+        gpt_neox_mlp.proj.weight.data
+    )
+    gpt_neox_mlp.proj.bias.data = torch.ones_like(
+        gpt_neox_mlp.proj.bias.data
+    )
     gpt_neox_mlp.reset_super_network()
     out_large = gpt_neox_mlp(input)
     assert out_large.shape == (8, 64)
@@ -71,11 +81,17 @@ def test_LLaMAMLP():
     config.intermediate_size = 64 * 4
     llama_mlp = LLaMAMLP(config)
     # init weights and biases
-    llama_mlp.fc_1.weight.data = torch.ones_like(llama_mlp.fc_1.weight.data)
+    llama_mlp.fc_1.weight.data = torch.ones_like(
+        llama_mlp.fc_1.weight.data
+    )
     llama_mlp.fc_1.bias.data = torch.ones_like(llama_mlp.fc_1.bias.data)
-    llama_mlp.fc_2.weight.data = torch.ones_like(llama_mlp.fc_2.weight.data)
+    llama_mlp.fc_2.weight.data = torch.ones_like(
+        llama_mlp.fc_2.weight.data
+    )
     llama_mlp.fc_2.bias.data = torch.ones_like(llama_mlp.fc_2.bias.data)
-    llama_mlp.proj.weight.data = torch.ones_like(llama_mlp.proj.weight.data)
+    llama_mlp.proj.weight.data = torch.ones_like(
+        llama_mlp.proj.weight.data
+    )
     llama_mlp.proj.bias.data = torch.ones_like(llama_mlp.proj.bias.data)
     llama_mlp.reset_super_network()
     out_large = llama_mlp(input)
@@ -140,11 +156,17 @@ def test_GemmaMLP():
     config.intermediate_size = 64 * 4
     gemma_mlp = GemmaMLP(config)
     # init weights and biases
-    gemma_mlp.fc_1.weight.data = torch.ones_like(gemma_mlp.fc_1.weight.data)
+    gemma_mlp.fc_1.weight.data = torch.ones_like(
+        gemma_mlp.fc_1.weight.data
+    )
     gemma_mlp.fc_1.bias.data = torch.ones_like(gemma_mlp.fc_1.bias.data)
-    gemma_mlp.fc_2.weight.data = torch.ones_like(gemma_mlp.fc_2.weight.data)
+    gemma_mlp.fc_2.weight.data = torch.ones_like(
+        gemma_mlp.fc_2.weight.data
+    )
     gemma_mlp.fc_2.bias.data = torch.ones_like(gemma_mlp.fc_2.bias.data)
-    gemma_mlp.proj.weight.data = torch.ones_like(gemma_mlp.proj.weight.data)
+    gemma_mlp.proj.weight.data = torch.ones_like(
+        gemma_mlp.proj.weight.data
+    )
     gemma_mlp.proj.bias.data = torch.ones_like(gemma_mlp.proj.bias.data)
     gemma_mlp.reset_super_network()
     out_large = gemma_mlp(input)

--- a/test/test_mlp.py
+++ b/test/test_mlp.py
@@ -9,6 +9,7 @@ from litgpt.model import (
 from litgpt.model import (
     LLaMAMLP as LitLLaMAMLP,
 )
+
 from lobotomy.models.gpt.blocks import GemmaMLP, GptNeoxMLP, LLaMAMLP
 
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1,8 +1,8 @@
-from lobotomy.models.gpt import GPT
-from litgpt import Config
-import torch
 import pytest
+import torch
+from litgpt import Config
 from litgpt.model import GPT as LitGPT
+from lobotomy.models.gpt import GPT
 
 
 @pytest.mark.parametrize("sample_random_indices", [True, False])
@@ -24,24 +24,52 @@ def test_gpt(sample_random_indices):
     config.lm_head_bias = True
     config.fix_head_size = False
     gpt = GPT(config)
-    gpt.transformer.wte.weight.data = torch.ones_like(gpt.transformer.wte.weight.data)
+    gpt.transformer.wte.weight.data = torch.ones_like(
+        gpt.transformer.wte.weight.data
+    )
     gpt.lm_head.weight.data = torch.ones_like(gpt.lm_head.weight.data)
     gpt.lm_head.bias.data = torch.ones_like(gpt.lm_head.bias.data)
-    gpt.transformer.ln_f.weight.data = torch.ones_like(gpt.transformer.ln_f.weight.data)
+    gpt.transformer.ln_f.weight.data = torch.ones_like(
+        gpt.transformer.ln_f.weight.data
+    )
 
     for block in gpt.transformer.h:
-        block.attn.attn.weight.data = torch.ones_like(block.attn.attn.weight.data)
-        block.attn.attn.bias.data = torch.ones_like(block.attn.attn.bias.data)
-        block.attn.proj.bias.data = torch.ones_like(block.attn.proj.bias.data)
-        block.attn.proj.weight.data = torch.ones_like(block.attn.proj.weight.data)
-        block.mlp.fc_1.weight.data = torch.ones_like(block.mlp.fc_1.weight.data)
-        block.mlp.fc_1.bias.data = torch.ones_like(block.mlp.fc_1.bias.data)
-        block.mlp.fc_2.weight.data = torch.ones_like(block.mlp.fc_2.weight.data)
-        block.mlp.fc_2.bias.data = torch.ones_like(block.mlp.fc_2.bias.data)
-        block.mlp.proj.weight.data = torch.ones_like(block.mlp.proj.weight.data)
-        block.mlp.proj.bias.data = torch.ones_like(block.mlp.proj.bias.data)
-        block.norm_1.weight.data = torch.ones_like(block.norm_1.weight.data)
-        block.norm_2.weight.data = torch.ones_like(block.norm_2.weight.data)
+        block.attn.attn.weight.data = torch.ones_like(
+            block.attn.attn.weight.data
+        )
+        block.attn.attn.bias.data = torch.ones_like(
+            block.attn.attn.bias.data
+        )
+        block.attn.proj.bias.data = torch.ones_like(
+            block.attn.proj.bias.data
+        )
+        block.attn.proj.weight.data = torch.ones_like(
+            block.attn.proj.weight.data
+        )
+        block.mlp.fc_1.weight.data = torch.ones_like(
+            block.mlp.fc_1.weight.data
+        )
+        block.mlp.fc_1.bias.data = torch.ones_like(
+            block.mlp.fc_1.bias.data
+        )
+        block.mlp.fc_2.weight.data = torch.ones_like(
+            block.mlp.fc_2.weight.data
+        )
+        block.mlp.fc_2.bias.data = torch.ones_like(
+            block.mlp.fc_2.bias.data
+        )
+        block.mlp.proj.weight.data = torch.ones_like(
+            block.mlp.proj.weight.data
+        )
+        block.mlp.proj.bias.data = torch.ones_like(
+            block.mlp.proj.bias.data
+        )
+        block.norm_1.weight.data = torch.ones_like(
+            block.norm_1.weight.data
+        )
+        block.norm_2.weight.data = torch.ones_like(
+            block.norm_2.weight.data
+        )
 
     gpt.reset_super_network()
     input = torch.randint(0, 512, (8, 512))
@@ -101,20 +129,46 @@ def test_gpt(sample_random_indices):
     lit_gpt.lm_head.weight.data = gpt.lm_head.weight.data
     lit_gpt.lm_head.bias.data = gpt.lm_head.bias.data
     lit_gpt.transformer.wte.weight.data = gpt.transformer.wte.weight.data
-    lit_gpt.transformer.ln_f.weight.data = gpt.transformer.ln_f.weight.data
+    lit_gpt.transformer.ln_f.weight.data = (
+        gpt.transformer.ln_f.weight.data
+    )
     for block in lit_gpt.transformer.h:
-        block.attn.attn.weight.data = torch.ones_like(block.attn.attn.weight.data)
-        block.attn.attn.bias.data = torch.ones_like(block.attn.attn.bias.data)
-        block.attn.proj.bias.data = torch.ones_like(block.attn.proj.bias.data)
-        block.attn.proj.weight.data = torch.ones_like(block.attn.proj.weight.data)
-        block.mlp.fc_1.weight.data = torch.ones_like(block.mlp.fc_1.weight.data)
-        block.mlp.fc_1.bias.data = torch.ones_like(block.mlp.fc_1.bias.data)
-        block.mlp.fc_2.weight.data = torch.ones_like(block.mlp.fc_2.weight.data)
-        block.mlp.fc_2.bias.data = torch.ones_like(block.mlp.fc_2.bias.data)
-        block.mlp.proj.weight.data = torch.ones_like(block.mlp.proj.weight.data)
-        block.mlp.proj.bias.data = torch.ones_like(block.mlp.proj.bias.data)
-        block.norm_1.weight.data = torch.ones_like(block.norm_1.weight.data)
-        block.norm_2.weight.data = torch.ones_like(block.norm_2.weight.data)
+        block.attn.attn.weight.data = torch.ones_like(
+            block.attn.attn.weight.data
+        )
+        block.attn.attn.bias.data = torch.ones_like(
+            block.attn.attn.bias.data
+        )
+        block.attn.proj.bias.data = torch.ones_like(
+            block.attn.proj.bias.data
+        )
+        block.attn.proj.weight.data = torch.ones_like(
+            block.attn.proj.weight.data
+        )
+        block.mlp.fc_1.weight.data = torch.ones_like(
+            block.mlp.fc_1.weight.data
+        )
+        block.mlp.fc_1.bias.data = torch.ones_like(
+            block.mlp.fc_1.bias.data
+        )
+        block.mlp.fc_2.weight.data = torch.ones_like(
+            block.mlp.fc_2.weight.data
+        )
+        block.mlp.fc_2.bias.data = torch.ones_like(
+            block.mlp.fc_2.bias.data
+        )
+        block.mlp.proj.weight.data = torch.ones_like(
+            block.mlp.proj.weight.data
+        )
+        block.mlp.proj.bias.data = torch.ones_like(
+            block.mlp.proj.bias.data
+        )
+        block.norm_1.weight.data = torch.ones_like(
+            block.norm_1.weight.data
+        )
+        block.norm_2.weight.data = torch.ones_like(
+            block.norm_2.weight.data
+        )
     out_lit_large = lit_gpt(input)
     assert torch.all(out_lit_large == out_large)
 
@@ -127,7 +181,9 @@ def test_gpt(sample_random_indices):
     lit_gpt_small.lm_head.weight.data = torch.ones_like(
         lit_gpt_small.lm_head.weight.data
     )
-    lit_gpt_small.lm_head.bias.data = torch.ones_like(lit_gpt_small.lm_head.bias.data)
+    lit_gpt_small.lm_head.bias.data = torch.ones_like(
+        lit_gpt_small.lm_head.bias.data
+    )
     lit_gpt_small.transformer.wte.weight.data = torch.ones_like(
         lit_gpt_small.transformer.wte.weight.data
     )
@@ -135,15 +191,35 @@ def test_gpt(sample_random_indices):
         lit_gpt_small.transformer.ln_f.weight.data
     )
     for block in lit_gpt_small.transformer.h:
-        block.attn.attn.weight.data = torch.ones_like(block.attn.attn.weight.data)
-        block.attn.attn.bias.data = torch.ones_like(block.attn.attn.bias.data)
-        block.attn.proj.bias.data = torch.ones_like(block.attn.proj.bias.data)
-        block.attn.proj.weight.data = torch.ones_like(block.attn.proj.weight.data)
-        block.mlp.fc_1.weight.data = torch.ones_like(block.mlp.fc_1.weight.data)
-        block.mlp.fc_1.bias.data = torch.ones_like(block.mlp.fc_1.bias.data)
-        block.mlp.fc_2.weight.data = torch.ones_like(block.mlp.fc_2.weight.data)
-        block.mlp.fc_2.bias.data = torch.ones_like(block.mlp.fc_2.bias.data)
-        block.mlp.proj.weight.data = torch.ones_like(block.mlp.proj.weight.data)
-        block.mlp.proj.bias.data = torch.ones_like(block.mlp.proj.bias.data)
+        block.attn.attn.weight.data = torch.ones_like(
+            block.attn.attn.weight.data
+        )
+        block.attn.attn.bias.data = torch.ones_like(
+            block.attn.attn.bias.data
+        )
+        block.attn.proj.bias.data = torch.ones_like(
+            block.attn.proj.bias.data
+        )
+        block.attn.proj.weight.data = torch.ones_like(
+            block.attn.proj.weight.data
+        )
+        block.mlp.fc_1.weight.data = torch.ones_like(
+            block.mlp.fc_1.weight.data
+        )
+        block.mlp.fc_1.bias.data = torch.ones_like(
+            block.mlp.fc_1.bias.data
+        )
+        block.mlp.fc_2.weight.data = torch.ones_like(
+            block.mlp.fc_2.weight.data
+        )
+        block.mlp.fc_2.bias.data = torch.ones_like(
+            block.mlp.fc_2.bias.data
+        )
+        block.mlp.proj.weight.data = torch.ones_like(
+            block.mlp.proj.weight.data
+        )
+        block.mlp.proj.bias.data = torch.ones_like(
+            block.mlp.proj.bias.data
+        )
     out_lit_small = lit_gpt_small(input)
     assert torch.all(out_lit_small == out_small)

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -2,6 +2,7 @@ import pytest
 import torch
 from litgpt import Config
 from litgpt.model import GPT as LitGPT
+
 from lobotomy.models.gpt import GPT
 
 

--- a/test/test_norms.py
+++ b/test/test_norms.py
@@ -1,7 +1,5 @@
 import torch
-
 from litgpt.model import RMSNorm
-
 from lobotomy.modules.layernorm import LayerNorm as LayerNormSuper
 from lobotomy.modules.rmsnorm import RMSNorm as RMSNormSuper
 

--- a/test/test_norms.py
+++ b/test/test_norms.py
@@ -1,5 +1,6 @@
 import torch
 from litgpt.model import RMSNorm
+
 from lobotomy.modules.layernorm import LayerNorm as LayerNormSuper
 from lobotomy.modules.rmsnorm import RMSNorm as RMSNormSuper
 

--- a/test/test_parameters.py
+++ b/test/test_parameters.py
@@ -1,5 +1,4 @@
 from lobotomy.metrics.parameters import compute_parameters
-
 from test.test_training_strategies import MLP
 
 

--- a/test/test_search.py
+++ b/test/test_search.py
@@ -1,8 +1,9 @@
 import numpy as np
 import pytest
+from syne_tune.config_space import randint
+
 from lobotomy.search import multi_objective_search
 from lobotomy.search.baselines import methods
-from syne_tune.config_space import randint
 
 
 def objective(config, **kwargs):

--- a/test/test_search.py
+++ b/test/test_search.py
@@ -1,9 +1,8 @@
-import pytest
 import numpy as np
-
-from syne_tune.config_space import randint
+import pytest
 from lobotomy.search import multi_objective_search
 from lobotomy.search.baselines import methods
+from syne_tune.config_space import randint
 
 
 def objective(config, **kwargs):
@@ -24,7 +23,8 @@ def test_multi_objective_search(search_strategy, num_samples=5):
     )
 
     assert all(
-        key in results for key in ["costs", "configs", "runtime", "is_pareto_optimal"]
+        key in results
+        for key in ["costs", "configs", "runtime", "is_pareto_optimal"]
     )
 
     assert results["costs"].shape == (num_samples, 2)
@@ -34,13 +34,18 @@ def test_multi_objective_search(search_strategy, num_samples=5):
 
     if search_strategy != "nsga2":
         # check that first config are the initial design
-        upper_bound = {hp_name: hp.upper for hp_name, hp in search_space.items()}
+        upper_bound = {
+            hp_name: hp.upper for hp_name, hp in search_space.items()
+        }
         assert results["configs"][0] == upper_bound
 
-        lower_bound = {hp_name: hp.lower for hp_name, hp in search_space.items()}
+        lower_bound = {
+            hp_name: hp.lower for hp_name, hp in search_space.items()
+        }
         assert results["configs"][1] == lower_bound
 
         mid_point = {
-            hp_name: (hp.upper - hp.lower) // 2 for hp_name, hp in search_space.items()
+            hp_name: (hp.upper - hp.lower) // 2
+            for hp_name, hp in search_space.items()
         }
         assert results["configs"][2] == mid_point

--- a/test/test_training_strategies.py
+++ b/test/test_training_strategies.py
@@ -2,6 +2,8 @@ import pytest
 import torch.nn as nn
 import torch.nn.functional
 from litgpt import Config
+from syne_tune.config_space import choice, randint
+
 from lobotomy.loss import DistillLoss
 from lobotomy.models.gpt import GPT
 from lobotomy.modules.linear import Linear
@@ -13,7 +15,6 @@ from lobotomy.training_strategies import (
     SandwichStrategy,
     StandardStrategy,
 )
-from syne_tune.config_space import choice, randint
 
 methods = [
     SandwichStrategy,

--- a/test/test_training_strategies.py
+++ b/test/test_training_strategies.py
@@ -1,21 +1,19 @@
 import pytest
 import torch.nn as nn
 import torch.nn.functional
-
-from syne_tune.config_space import randint, choice
-from lobotomy.loss import DistillLoss
-from lobotomy.training_strategies import (
-    SandwichStrategy,
-    RandomStrategy,
-    StandardStrategy,
-    RandomLinearStrategy,
-    ATS,
-)
 from litgpt import Config
+from lobotomy.loss import DistillLoss
 from lobotomy.models.gpt import GPT
-from lobotomy.sampling.random_sampler import RandomSampler
 from lobotomy.modules.linear import Linear
-
+from lobotomy.sampling.random_sampler import RandomSampler
+from lobotomy.training_strategies import (
+    ATS,
+    RandomLinearStrategy,
+    RandomStrategy,
+    SandwichStrategy,
+    StandardStrategy,
+)
+from syne_tune.config_space import choice, randint
 
 methods = [
     SandwichStrategy,

--- a/test/test_transformer_block.py
+++ b/test/test_transformer_block.py
@@ -1,8 +1,8 @@
 import torch
 from litgpt import Config
-from lobotomy.models.gpt.blocks import Block
 from litgpt.model import Block as LitBlock
 from litgpt.model import build_mask_cache, build_rope_cache
+from lobotomy.models.gpt.blocks import Block
 
 
 def test_block():
@@ -17,20 +17,32 @@ def test_block():
     config.max_seq_len = 512
     config.rotary_percentage = 0.25
     config.rope_n_elem = int(config.rotary_percentage * config.head_size)
-    cos, sin = build_rope_cache(config.max_seq_len, n_elem=config.rope_n_elem)
+    cos, sin = build_rope_cache(
+        config.max_seq_len, n_elem=config.rope_n_elem
+    )
 
     block = Block(config)
     input = torch.rand(8, 512, 64)
     mask = build_mask_cache(512)
-    block.attn.attn.weight.data = torch.ones_like(block.attn.attn.weight.data)
+    block.attn.attn.weight.data = torch.ones_like(
+        block.attn.attn.weight.data
+    )
     block.attn.attn.bias.data = torch.ones_like(block.attn.attn.bias.data)
     block.attn.proj.bias.data = torch.ones_like(block.attn.proj.bias.data)
-    block.attn.proj.weight.data = torch.ones_like(block.attn.proj.weight.data)
-    block.mlp.fc_1.weight.data = torch.ones_like(block.mlp.fc_1.weight.data)
+    block.attn.proj.weight.data = torch.ones_like(
+        block.attn.proj.weight.data
+    )
+    block.mlp.fc_1.weight.data = torch.ones_like(
+        block.mlp.fc_1.weight.data
+    )
     block.mlp.fc_1.bias.data = torch.ones_like(block.mlp.fc_1.bias.data)
-    block.mlp.fc_2.weight.data = torch.ones_like(block.mlp.fc_2.weight.data)
+    block.mlp.fc_2.weight.data = torch.ones_like(
+        block.mlp.fc_2.weight.data
+    )
     block.mlp.fc_2.bias.data = torch.ones_like(block.mlp.fc_2.bias.data)
-    block.mlp.proj.weight.data = torch.ones_like(block.mlp.proj.weight.data)
+    block.mlp.proj.weight.data = torch.ones_like(
+        block.mlp.proj.weight.data
+    )
     block.mlp.proj.bias.data = torch.ones_like(block.mlp.proj.bias.data)
     block.reset_super_network()
     out_large = block(input, cos, sin, mask)
@@ -44,16 +56,36 @@ def test_block():
     assert out_small.shape == (8, 512, 32)
 
     lit_block = LitBlock(config)
-    lit_block.attn.attn.weight.data = torch.ones_like(lit_block.attn.attn.weight.data)
-    lit_block.attn.attn.bias.data = torch.ones_like(lit_block.attn.attn.bias.data)
-    lit_block.attn.proj.bias.data = torch.ones_like(lit_block.attn.proj.bias.data)
-    lit_block.attn.proj.weight.data = torch.ones_like(lit_block.attn.proj.weight.data)
-    lit_block.mlp.fc_1.weight.data = torch.ones_like(lit_block.mlp.fc_1.weight.data)
-    lit_block.mlp.fc_1.bias.data = torch.ones_like(lit_block.mlp.fc_1.bias.data)
-    lit_block.mlp.fc_2.weight.data = torch.ones_like(lit_block.mlp.fc_2.weight.data)
-    lit_block.mlp.fc_2.bias.data = torch.ones_like(lit_block.mlp.fc_2.bias.data)
-    lit_block.mlp.proj.weight.data = torch.ones_like(lit_block.mlp.proj.weight.data)
-    lit_block.mlp.proj.bias.data = torch.ones_like(lit_block.mlp.proj.bias.data)
+    lit_block.attn.attn.weight.data = torch.ones_like(
+        lit_block.attn.attn.weight.data
+    )
+    lit_block.attn.attn.bias.data = torch.ones_like(
+        lit_block.attn.attn.bias.data
+    )
+    lit_block.attn.proj.bias.data = torch.ones_like(
+        lit_block.attn.proj.bias.data
+    )
+    lit_block.attn.proj.weight.data = torch.ones_like(
+        lit_block.attn.proj.weight.data
+    )
+    lit_block.mlp.fc_1.weight.data = torch.ones_like(
+        lit_block.mlp.fc_1.weight.data
+    )
+    lit_block.mlp.fc_1.bias.data = torch.ones_like(
+        lit_block.mlp.fc_1.bias.data
+    )
+    lit_block.mlp.fc_2.weight.data = torch.ones_like(
+        lit_block.mlp.fc_2.weight.data
+    )
+    lit_block.mlp.fc_2.bias.data = torch.ones_like(
+        lit_block.mlp.fc_2.bias.data
+    )
+    lit_block.mlp.proj.weight.data = torch.ones_like(
+        lit_block.mlp.proj.weight.data
+    )
+    lit_block.mlp.proj.bias.data = torch.ones_like(
+        lit_block.mlp.proj.bias.data
+    )
     out_lit_large = lit_block(input, cos, sin, mask)
     assert torch.all(out_lit_large == out_large)
 

--- a/test/test_transformer_block.py
+++ b/test/test_transformer_block.py
@@ -2,6 +2,7 @@ import torch
 from litgpt import Config
 from litgpt.model import Block as LitBlock
 from litgpt.model import build_mask_cache, build_rope_cache
+
 from lobotomy.models.gpt.blocks import Block
 
 


### PR DESCRIPTION
Adding `isort`-style sorting to `ruff` via `pyproject.toml`

Closes #63 

TODOs: 
- [ ] fix an issue where local code is not sorted correctly and mixed in together with 3rd party imports (ask eddie) @timurcarstensen 