### PR TITLE
pass device to rope cache

### DIFF
--- a/lobotomy/models/gpt/model.py
+++ b/lobotomy/models/gpt/model.py
@@ -202,7 +202,7 @@ class GPT(nn.Module):
                             self.config.rotary_percentage
                             * (self.sub_network_n_embd // self.sub_network_num_heads[i])
                         ),
-                        device=idx.device
+                        device=idx.device,
                     )
                 else:
                     cos, sin = build_rope_cache(
@@ -211,13 +211,13 @@ class GPT(nn.Module):
                             self.config.rotary_percentage
                             * (self.sub_network_n_embd // self.sub_network_num_heads)
                         ),
-                        device=idx.device
+                        device=idx.device,
                     )
             else:
                 cos, sin = build_rope_cache(
                     T,
                     n_elem=int(self.config.rotary_percentage * (self.config.head_size)),
-                    device=idx.device
+                    device=idx.device,
                 )
 
             cos, sin, mask = self.process_rope_cache(cos, sin, input_pos, T)


### PR DESCRIPTION
makes sure that all tensors are on the same device

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.