### PR TITLE
refactor: Remove dead `setup.py` file and Python 2 artifacts

### DIFF
--- a/benchmarks/plm_pruning/bert.py
+++ b/benchmarks/plm_pruning/bert.py
@@ -12,7 +12,7 @@ from search_spaces import (
 )
 
 
-class BERTSuperNetMixin(object):
+class BERTSuperNetMixin:
     search_space = None
     handles = None
 

--- a/benchmarks/plm_pruning/data_wrapper/data_wrapper.py
+++ b/benchmarks/plm_pruning/data_wrapper/data_wrapper.py
@@ -8,7 +8,7 @@ from transformers import AutoTokenizer, DataCollatorWithPadding, default_data_co
 logger = logging.getLogger(__name__)
 
 
-class DataWrapper(object):
+class DataWrapper:
     def __init__(self, training_args, model_args, data_args):
         self.training_args = training_args
         self.model_args = model_args

--- a/benchmarks/plm_pruning/data_wrapper/data_wrapper_alpaca.py
+++ b/benchmarks/plm_pruning/data_wrapper/data_wrapper_alpaca.py
@@ -133,7 +133,7 @@ class SupervisedDataset(Dataset):
 
 
 @dataclass
-class DataCollatorForSupervisedDataset(object):
+class DataCollatorForSupervisedDataset:
     """Collate benchmarks for supervised fine-tuning."""
 
     tokenizer: transformers.PreTrainedTokenizer

--- a/benchmarks/plm_pruning/search_spaces.py
+++ b/benchmarks/plm_pruning/search_spaces.py
@@ -4,7 +4,7 @@ import torch
 from syne_tune.config_space import randint, choice, Domain, ordinal
 
 
-class SearchSpace(object):
+class SearchSpace:
     """
     Setting the mask to 1 means we keep the corresponding head / unit
     """

--- a/whittle/sampling/random_sampler.py
+++ b/whittle/sampling/random_sampler.py
@@ -5,7 +5,7 @@ import numpy as np
 from syne_tune.config_space import Domain, Categorical
 
 
-class RandomSampler(object):
+class RandomSampler:
     def __init__(self, config_space: Dict, seed: Optional[int] = None):
         self.config_space = config_space
         self.rng = np.random.RandomState(seed)

--- a/whittle/training_strategies/base_strategy.py
+++ b/whittle/training_strategies/base_strategy.py
@@ -4,7 +4,7 @@ from whittle.loss import DistillLoss
 import torch
 
 
-class BaseTrainingStrategy(object):
+class BaseTrainingStrategy:
     """
     Base Training Strategy.
 


### PR DESCRIPTION
#### Reference Issues/PRs
None

#### What does this implement/fix? Explain your changes.
* Remove empty `setup.py` (everything is statically defined through `pyproject.toml`)
    * Removes the need to download the `setup.py` to figure out dynamic project specification which makes installation and dependancy resolution faster for dependant libraries)
* Remove inheretance from `object`. All classes inherently inhereit from this since Python 3 in so called "new style classes".


#### Minimal Example / How should this PR be tested?


#### Any other comments?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.