### PR TITLE
doc: Setup documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,25 @@
+name: Unit Tests
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
+          cache: 'pip'
+      - name: Install
+        run: pip install ".[dev]"
+      - name: Run mkdocs
+        # You can include `--strict` to treat warnings as errors
+        # Advised if you can sort out the typing issues
+        run: mkdocs build --clean

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,12 @@ cd whittle
 pip install -e ".[dev]"  # Install what's here (the `.` part) and install the extra dev dependancies
 ```
 
+Setup `pre-commit` to run on every commit
+
+```bash
+pre-commit install
+```
+
 ## Testing
 
 ```bash

--- a/docs/_scripts/api_generator.py
+++ b/docs/_scripts/api_generator.py
@@ -1,0 +1,32 @@
+"""Generate the code reference pages and navigation.
+
+# https://mkdocstrings.github.io/recipes/
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import mkdocs_gen_files
+
+logger = logging.getLogger(__name__)
+
+for path in sorted(Path("whittle").rglob("*.py")):
+    module_path = path.relative_to(".").with_suffix("")
+    doc_path = path.relative_to(".").with_suffix(".md")
+    full_doc_path = Path("api", doc_path)
+
+    parts = tuple(module_path.parts)
+
+    if parts[-1] in ("__main__", "__version__", "__init__"):
+        continue
+
+    if any(part.startswith("_") for part in parts):
+        continue
+
+    with mkdocs_gen_files.open(full_doc_path, "w") as fd:
+        ident = ".".join(parts)
+        fd.write(f"::: {ident}")
+
+    mkdocs_gen_files.set_edit_path(full_doc_path, path)

--- a/docs/_scripts/clean_log_output.py
+++ b/docs/_scripts/clean_log_output.py
@@ -1,0 +1,37 @@
+"""The module is a hook which disables warnings and log messages which pollute the
+doc build output.
+
+One possible downside is if one of these modules ends up giving an actual
+error, such as OpenML failing to retrieve a dataset. I tried to make sure ERROR
+log message are still allowed through.
+"""
+
+from __future__ import annotations
+
+import logging
+import warnings
+from typing import Any
+
+import mkdocs
+import mkdocs.plugins
+import mkdocs.structure.pages
+
+log = logging.getLogger("mkdocs")
+
+
+@mkdocs.plugins.event_priority(-50)
+def on_startup(**kwargs: Any) -> None:
+    # Remove deperecation warnings from the doc build log
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+
+
+def on_pre_page(
+    page: mkdocs.structure.pages.Page,
+    config: Any,
+    files: Any,
+) -> mkdocs.structure.pages.Page | None:
+    # If you want to remove certain loggers from doc output, you can do it here
+
+    # logging.getLogger("smac").setLevel(logging.ERROR)
+    # logging.getLogger("openml").setLevel(logging.ERROR)
+    return page

--- a/docs/_scripts/debug_which_page_is_being_rendered.py
+++ b/docs/_scripts/debug_which_page_is_being_rendered.py
@@ -1,0 +1,24 @@
+"""This module is a hook that when any code is being rendered, it will
+print the path to the file being rendered.
+
+This makes it easier to identify which file is being rendered when an error happens.
+"""
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+import mkdocs
+import mkdocs.plugins
+
+if TYPE_CHECKING:
+    import mkdocs.structure.pages
+
+log = logging.getLogger("mkdocs")
+
+def on_pre_page(
+    page: mkdocs.structure.pages.Page,
+    config: Any,
+    files: Any,
+) -> mkdocs.structure.pages.Page | None:
+    log.info(f"{page.file.src_path}")

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,1 @@
+--8<-- "CONTRIBUTING.md"

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,100 @@
+## Viewing docs locally
+
+```bash
+mkdocs serve  # that's it
+```
+
+!!! todo "Deployment"
+
+    I'll set up `mike` and document how to use that to deploy docs to github pages.
+
+## Quickstart Mkdocs
+This is your [bible](phttps://squidfunk.github.io/mkdocs-material/reference/)
+This is just an overview of some features.
+
+```python
+print("hello world")
+```
+
+```bash
+whittle --help  # (1)!
+```
+
+1. Look, an admonation! You can put `code` in here too!
+```python
+print("cool")
+```
+
+You can create tabbed blocks which are super useful.
+
+=== "Python"
+
+    ```python hl_lines="3-4"
+    print("hello from tabbed block 1")
+
+    print("Hello from highlight")
+    print("Hello from highlight as well")
+    ```
+
+=== "cli"
+
+    ```bash
+    whittle --help
+    ```
+
+=== "Diagram using mermaid"
+
+    ``` mermaid
+    graph LR
+      A[Start] --> B{Error?};
+      B -->|Yes| C[Hmm...];
+      C --> D[Debug];
+      D --> B;
+      B ---->|No| E[Yay!];
+    ```
+
+!!! warning
+
+    This is a warning and set to be expanded with `!!!`
+
+??? tip "My Tip name"
+
+    This is a closed tip with `???`
+
+To link to internal api docs, use the following.
+
+```
+[LS][whittle.search.local_search]
+```
+
+See [LS][whittle.search.local_search] for more information.
+
+To link to api docs in other codebases, you can directly reference them
+in much the same way you would import them, for example, this references
+the [`ProcessPoolExecutor`][concurrent.futures.ProcessPoolExecutor] class in the `concurrent.futures` module.
+The backticks are optional, they just make the link look like code.
+
+```
+[`ProcessPoolExecutor`][concurrent.futures.ProcessPoolExecutor]
+```
+
+You can use `()` like you normally would to link to html links,
+i.e. [Python Docs](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ProcessPoolExecutor).
+
+```
+[Python Docs](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ProcessPoolExecutor).
+```
+
+You can also link directly to other pages in your repo if you need using a relative syntax,
+
+```
+[API](./contributing)
+```
+
+You can directly include the content of other files if you need, but I've rarely had a use for it. The main one
+was really for including the `CONTIBUTING.md` file in the `docs/contributing.md` file.
+
+This is all that has to be done. The path is relative to the root of the repo (where you execute the command from).
+```
+--8<-- "CONTRIBUTING.md"
+```

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -173,3 +173,4 @@ nav:
   - Home: "index.md"
     # Auto generated with docs/api_generator.py
   - API: "api/"
+  - Contributing: "contributing.md"

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -1,0 +1,175 @@
+# This project uses mkdocs to generate the documentation.
+# Specifically it uses the mkdocs-material theme, which provides a whole
+# host of nice features and customization
+#
+# mkdocs: https://www.mkdocs.org/getting-started/#getting-started-with-mkdocs
+# mkdocs-material: https://squidfunk.github.io/mkdocs-material/
+#
+# Please refer to these links for more information on how to use mkdocs
+#
+# For serving the docs locally, you can take a look at the `justfile` at
+# the root of this repository, it contains a few commands for generating the docs
+# with different levels of execution.
+#
+# Please refer to individual sections for any additional notes
+site_name: "whittle"
+repo_url: https://github.com/whittle-org/whittle/
+repo_name: whittle-org/whittle
+
+theme:
+  name: material
+  # logo: assets/automl_org.png
+  # favicon: assets/automl_org.png
+  icon:
+    repo: fontawesome/brands/github
+  features:
+    - content.code.annotate
+    - content.code.copy
+    - navigation.footer
+    # - navigation.sections
+    - navigation.tabs
+    - navigation.prune
+    # - navigation.tabs.sticky
+    - toc.follow
+    - toc.integrate
+    - header.autohide
+    - search.suggest
+    - search.highlight
+    - search.share
+  font:
+    text: Roboto
+    code: Roboto Mono
+  palette:
+    - scheme: slate
+      media: "(prefers-color-scheme: dark)"
+      primary: indigo
+      accent: deep purple
+      toggle:
+        icon: material/eye-outline
+        name: Switch to light mode
+
+    # Palette toggle for light mode
+    - scheme: default
+      media: "(prefers-color-scheme: light)"
+      primary: indigo
+      accent: deep purple
+      toggle:
+        icon: material/eye
+        name: Switch to dark mode
+
+
+# The `mike` versioning provider
+# https://github.com/jimporter/mike
+#
+# This is what allows us to create versioned docs in the github cli
+extra:
+  version:
+    provider: mike
+  social:
+    - icon: fontawesome/brands/github
+
+watch:
+  - whittle
+  - docs
+
+markdown_extensions:
+  - admonition
+  - tables
+  - attr_list
+  - md_in_html
+  - toc:
+      permalink: "#"
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.magiclink:
+      hide_protocol: true
+      repo_url_shortener: true
+      repo_url_shorthand: true
+      user: whittle-org
+      repo: whittle
+  - pymdownx.highlight
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.details
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.superfences:
+      custom_fences:
+      - name: mermaid
+        class: mermaid
+        format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+
+# These are files that are run when serving the docs.
+hooks:
+  # This prevents logging messages from polluting the doc build
+  - docs/_scripts/clean_log_output.py
+  # This hook simply prints the page being rendered for
+  # an easier time debugging any issues with code in docs
+  - docs/_scripts/debug_which_page_is_being_rendered.py
+
+plugins:
+  - search
+  - autorefs
+  - mike:
+      version_selector: true
+      css_dir: css
+      javascript_dir: js
+      canonical_version: latest
+  - gen-files:
+      scripts:
+        # Uses this script to generate the API documentation
+        - docs/_scripts/api_generator.py
+  - literate-nav:
+        nav_file: SUMMARY.md
+  - mkdocstrings:
+      default_handler: python
+      enable_inventory: true
+      handlers:
+        python:
+          paths: [src]
+          # Extra objects which allow for linking to external docs
+          import:
+            - 'https://docs.python.org/3/objects.inv'
+            - 'https://numpy.org/doc/stable/objects.inv'
+            - 'https://pandas.pydata.org/docs/objects.inv'
+            - 'https://pytorch.org/docs/stable/objects.inv'
+          # Please do not try to change these without having
+          # looked at all of the documentation and seeing if it
+          # causes the API docs to look weird anywhere.
+          options:  # https://mkdocstrings.github.io/python/usage/
+            docstring_section_style: spacy
+            docstring_options:
+              ignore_init_summary: true
+              trim_doctest_flags: true
+              returns_multiple_items: false
+            show_docstring_attributes: true
+            show_docstring_description: true
+            show_root_heading: true
+            show_root_toc_entry: true
+            show_object_full_path: false
+            show_root_members_full_path: false
+            signature_crossrefs: true
+            merge_init_into_class: true
+            show_symbol_type_heading: true
+            show_symbol_type_toc: true
+            docstring_style: google
+            inherited_members: true
+            show_if_no_docstring: false
+            show_bases: true
+            show_source: true
+            members_order: "alphabetical"
+            group_by_category: true
+            show_signature: true
+            separate_signature: true
+            show_signature_annotations: true
+            # Hide private members with prefix `_` but do not hide methods starting with `__`
+            filters:
+              - "!^_[^_]"
+
+nav:
+  - Home: "index.md"
+    # Auto generated with docs/api_generator.py
+  - API: "api/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,11 +40,22 @@ homepage = "https://github.com/whittle-org/whittle"
 
 [project.optional-dependencies]
 dev = [
+  # -- deploy --
+  "build",
+  # -- ci --
   "pre-commit",
   "pytest>=8",
-  "build",
   "ruff",
   "mypy",
+  # -- docs --
+  "mike",
+  "mkdocs",
+  "mkdocs-material",
+  "mkdocs-autorefs",
+  "mkdocs-gen-files",
+  "mkdocs-literate-nav",
+  "mkdocstrings[python]",
+  "black",  # Allows mkdocstrings to do formatting...
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
#### Reference Issues/PRs
None

#### What does this implement/fix? Explain your changes.
* Uses `mkdocs` (`mkdocs-material`) to generate documentation. Right now there's just a dummy `index.md` with some examples on writing documentation.
* Generates `API` documentation automatically.
* Added a page for `contributing.md` which links to `CONTRIBUTING.md` in the root.
* Workflow to make sure docs render (non-strict)

#### Minimal Example / How should this PR be tested?

```bash
pip install -e ".[dev]"
mkdocs serve
```

#### Any other comments?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.