### PR TITLE
ci: automatic release workflow

### DIFF
--- a/.github/workflows/pr-conventional-commit.yml
+++ b/.github/workflows/pr-conventional-commit.yml
@@ -1,0 +1,15 @@
+name: PR Conventional Commit Validation
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+jobs:
+  validate-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: PR Conventional Commit Validation
+        uses:  ytanikin/PRConventionalCommits@1.2.0
+        with:
+          task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert"]'
+          add_label: 'false'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,160 @@
+name: release
+on:
+  workflow_dispatch:
+permissions:
+  contents: write
+jobs:
+  test-code:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: pip
+      - run: python -m pip install ".[dev]"
+      - run: pytest ${{ env.test-dir }}
+  test-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: pip
+      - run: python -m pip install ".[dev]"
+      - run: mkdocs build --clean --strict
+  # Need to ensure we bump before we create any artifacts
+  bump:
+    runs-on: ubuntu-latest
+    needs: [test-code, test-docs]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-tags: 1  # Essential to later commitizen
+          fetch-depth: 0  # Recommended by the action
+          token: ${{ secrets.PUSH_ACCESS }}
+      - run: git tag  # Debug statement
+      - name: Create bump and changelog
+        uses: commitizen-tools/commitizen-action@master
+        id: cz
+        with:
+          github_token: ${{ secrets.PUSH_ACCESS }}
+          debug: true
+          changelog_increment_filename: changelog-increment.md
+      - run: |
+          mkdir changelog-output
+          mv changelog-increment.md changelog-output/changelog-increment.md
+          cat changelog-output/changelog-increment.md
+      - name: Upload the changelog
+        uses: actions/upload-artifact@v4
+        with:
+          name: changelog
+          path: changelog-output
+
+  build:
+    needs: [bump]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: "main"  # Necessary to download the latest of main as this will have been updated on the step before
+          fetch-tags: 1
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: pip
+      - run: python -m pip install build
+      - run: python -m build --sdist
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-output
+          path: dist
+
+  docs:
+    needs: [bump]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: "main"  # Necessary to download the latest of main as this will have been updated on the step before
+          fetch-tags: 1
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: pip
+      - run: python -m pip install ".[dev]"
+      - name: "Deploy Docs"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name doc-bot
+          git config user.email doc-bot@amltk.com
+          current_version=$(git tag | sort --version-sort | tail -n 1)
+
+          # This block will rename previous retitled versions
+          retitled_versions=$(mike list -j | jq ".[] | select(.title != .version) | .version" | tr -d '"')
+          for version in $retitled_versions; do
+            mike retitle "${version}" "${version}"
+          done
+
+          echo "Deploying docs for ${current_version}"
+          mike deploy \
+            --push \
+            --title "${current_version} (latest)" \
+            --update-aliases \
+            "${current_version}" \
+            "latest"
+  release:
+    needs: [docs, build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: "main"  # Necessary to download the latest of main as this will have been updated on the step before
+          fetch-tags: 1
+          fetch-depth: 0
+      - name: Download the build artifiact
+        uses: actions/download-artifact@v4
+        with:
+            name: build-output
+            path: dist
+      - run: ls -R dist
+      - name: Download the changelog
+        uses: actions/download-artifact@v4
+        with:
+          name: changelog
+          path: changelog-output
+      - run: |
+          ls -R changelog-output
+          mv changelog-output/changelog-increment.md changelog-increment.md
+          cat changelog-increment.md
+      - name: "Create Github Release"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          current_version=$(git tag | sort --version-sort | tail -n 1)
+          echo "Release for ${current_version}"
+          gh release create  \
+            --generate-notes \
+            --notes-file changelog-increment.md \
+            --verify-tag \
+            "${current_version}" "dist/whittle-${current_version}.tar.gz"
+  publish:
+    needs: [release]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: "main"  # Necessary to download the latest of main as this will have been updated on the step before
+      - uses: actions/download-artifact@v4
+        with:
+            name: build-output
+            path: dist
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,14 +6,21 @@ permissions:
 jobs:
   test-code:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # Run in all these versions of Python
+        python-version: ["3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
-          cache: pip
-      - run: python -m pip install ".[dev]"
-      - run: pytest ${{ env.test-dir }}
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+      - name: Install
+        run: pip install ".[dev]"
+      - name: Run pytest
+        run: pytest -vvv
   test-docs:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name doc-bot
-          git config user.email doc-bot@amltk.com
+          git config user.email doc-bot@whittle.org
           current_version=$(git tag | sort --version-sort | tail -n 1)
 
           # This block will rename previous retitled versions

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,3 +45,7 @@ repos:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix, --no-cache]
       - id: ruff-format
+  - repo: https://github.com/commitizen-tools/commitizen
+    rev: v3.29.0
+    hooks:
+      - id: commitizen

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,14 +42,14 @@ If you do not use `cz commit` or make a commit with a conventional commit messag
 
 ## Signing commits
 
+**Note**: we recommend using SSH keys for signing commits for convenience (e.g., you can use the same key for commit signing and for authentication to GitHub).
+
 1. [Add a SSH (or GPG) key as a signing key to you GitHub account.](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#ssh-commit-signature-verification)
 2. [Configure `git` to use the key.](https://docs.github.com/en/authentication/managing-commit-signature-verification/telling-git-about-your-signing-key#telling-git-about-your-ssh-key)
-3. [Configure `commitizen` to use the key.](https://commitizen-tools.github.io/commitizen/config/#signing-commits)
 
+**Note**: if you don't configure commit signing globally, you will need to use `git commit -s`/`cz commit -s` to sign your commits.
 
-```bash
-cz commit
-```
+**Warning**: if you don't sign your commits, **your PR will not pass CI**.
 
 ## Release
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,33 @@ pre-commit install
 pytest
 ```
 
+## Conventional commits and Commitizen
+
+We use [commitizen](https://commitizen-tools.github.io/commitizen/) to manage commits.
+This enforces conventional commits.
+
+To make a commit, simply run:
+
+```bash
+cz commit
+```
+
+This will prompt you to enter a commit message and enforce conventional commit formatting.
+
+If you do not use `cz commit` or make a commit with a conventional commit message, **your PR will not pass CI**.
+
+
+## Signing commits
+
+1. [Add a SSH (or GPG) key as a signing key to you GitHub account.](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#ssh-commit-signature-verification)
+2. [Configure `git` to use the key.](https://docs.github.com/en/authentication/managing-commit-signature-verification/telling-git-about-your-signing-key#telling-git-about-your-ssh-key)
+3. [Configure `commitizen` to use the key.](https://commitizen-tools.github.io/commitizen/config/#signing-commits)
+
+
+```bash
+cz commit
+```
+
 ## Release
 
 Update the version in `pyproject.toml` first, say to `X.Y.Z`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,5 @@
 ## Contributing
 
-Work In Progress.
-
-
 ## Installation
 
 ```bash
@@ -49,9 +46,7 @@ If you do not use `cz commit` or make a commit with a conventional commit messag
 
 **Note**: if you don't configure commit signing globally, you will need to use `git commit -s`/`cz commit -s` to sign your commits.
 
-**Warning**: if you don't sign your commits, **your PR will not pass CI**.
-
-## Release
+<!-- ## Release
 
 Update the version in `pyproject.toml` first, say to `X.Y.Z`.
 If you maintain a changelog, update it.
@@ -75,7 +70,7 @@ pip install twine # If not already
 rm -rf ./dist  # Remove anything currently occupying the dist folder
 python -m build --sdist  # Build a source distribution
 twine upload dist/*  # Publish to PyPI
-```
+``` -->
 
 ## Documentation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dev = [
   "pytest>=8",
   "ruff",
   "mypy",
+  "commitizen",
   # -- docs --
   "mike",
   "mkdocs",


### PR DESCRIPTION
Adds an automatic release workflow

Changes: 
- adding `commitizen` as a development dependency
- adding `commitizen` as a pre-commit hook
- adding `pr-conventional-commits.yml`: a GH action to check whether the PR title conforms to conventional commits

TODOs: 
- [x] tagged releases / commits (not sure yet?)
- [x] Release workflow with publishing to PyPI (follow `amltk` setup)
- [x] Optional: enforce signed commits

Closes #92 