### PR TITLE
fix: support params, mag when sharing layer norm in phi-2

### DIFF
--- a/test/test_api.py
+++ b/test/test_api.py
@@ -283,7 +283,7 @@ class Test_WhittleLM:
         context = LM.tok_batch_encode([self.TEST_STRING])[0]
         res = LM._model_generate(context.to(gpt.device), max_length=10, stop=["\n\n"])
         res = LM.tok_decode(res[0])
-        assert res == "foo bar\n<bazhang>!info bar"
+        assert res == "foo bar\n<bazhang> !info bar"
 
     def test_evaluate(self, checkpoint_dir, out_dir):
         config = Config.from_file(str(checkpoint_dir / "model_config.yaml"))

--- a/whittle/metrics/mag.py
+++ b/whittle/metrics/mag.py
@@ -50,6 +50,8 @@ def weight_magnitude_mlp(mlp):
 
 
 def weight_magnitude_layer_norm(layer):
+    if layer is None:
+        return 0
     if isinstance(layer, LayerNorm):
         n = layer.sub_network_in_features
         mag = torch.sum(torch.abs(layer.weight[:n]))

--- a/whittle/metrics/parameters.py
+++ b/whittle/metrics/parameters.py
@@ -28,6 +28,8 @@ def params_embedding_layer(embedding: Embedding):
 
 
 def params_layer_normalization(normalization_layer: nn.Module):
+    if normalization_layer is None:
+        return 0
     if isinstance(normalization_layer, LayerNorm):
         return 2 * normalization_layer.sub_network_in_features
     elif isinstance(normalization_layer, RMSNorm):


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Layer norm layer can be none when sharing layer norms in the transformer blocks (for phi-2), this PR simply returns zero as magnitude, num_params when the layer norm layer is none 

Tests to generate text is also updated, to add an additional space: Check this faliure of lm-eval -harness https://github.com/EleutherAI/lm-evaluation-harness/actions/runs/11108810416/job/30862647665#step:5:1125