### PR TITLE
fix: handle device in GPT model properly

### DIFF
--- a/test/test_api.py
+++ b/test/test_api.py
@@ -283,7 +283,7 @@ class Test_WhittleLM:
         context = LM.tok_batch_encode([self.TEST_STRING])[0].to(device)
         res = LM._model_generate(context, max_length=10, stop=["\n\n"])
         res = LM.tok_decode(res[0])
-        assert res == "foo bar\n<bazhang>!info bar"
+        assert res == "foo bar\n<bazhang> !info bar"
 
     def test_evaluate(self, checkpoint_dir, out_dir):
         device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -169,17 +169,17 @@ class Test_WhittleLM:
     ]
 
     def test_logliklihood(self, checkpoint_dir, out_dir) -> None:
+        device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
         config = Config.from_file(str(checkpoint_dir / "model_config.yaml"))
         config.fix_head_size = True
         config.model_type = "gpt"
         config.tie_embeddings = False
-        gpt = GPT(config)
-        gpt.to(gpt.device)
+        gpt = GPT(config).to(device)
         gpt.name_or_path = "EleutherAI/pythia-70m"
 
         # model = LitGPT(config)
         gpt.load_state_dict(torch.load(str(checkpoint_dir / "lit_model.pth")))
-        LM = WhittleLM(pretrained=gpt, dtype="float32")
+        LM = WhittleLM(pretrained=gpt, dtype="float32", device=device)
         res = LM.loglikelihood(self.MULTIPLE_CH)
         _RES, _res = self.MULTIPLE_CH_RES, [r[0] for r in res]
         # log samples to CI
@@ -194,104 +194,104 @@ class Test_WhittleLM:
         assert (argmax_RES == argmax_res).all()
 
     def test_generate_until(self, checkpoint_dir) -> None:
+        device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
         config = Config.from_file(str(checkpoint_dir / "model_config.yaml"))
         config.fix_head_size = True
         config.model_type = "gpt"
         config.tie_embeddings = False
-        gpt = GPT(config)
-        gpt.to(gpt.device)
+        gpt = GPT(config).to(device)
         gpt.name_or_path = "EleutherAI/pythia-70m"
 
         # model = LitGPT(config)
         gpt.load_state_dict(torch.load(str(checkpoint_dir / "lit_model.pth")))
-        LM = WhittleLM(pretrained=gpt, dtype="float32")
+        LM = WhittleLM(pretrained=gpt, dtype="float32", device=device)
         res = LM.generate_until(self.generate_until)
         assert res == self.generate_until_RES
 
     def test_logliklihood_rolling(self, checkpoint_dir) -> None:
+        device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
         config = Config.from_file(str(checkpoint_dir / "model_config.yaml"))
         config.fix_head_size = True
         config.model_type = "gpt"
         config.tie_embeddings = False
-        gpt = GPT(config)
-        gpt.to(gpt.device)
+        gpt = GPT(config).to(device)
         gpt.name_or_path = "EleutherAI/pythia-70m"
 
         # model = LitGPT(config)
         gpt.load_state_dict(torch.load(str(checkpoint_dir / "lit_model.pth")))
-        LM = WhittleLM(pretrained=gpt, dtype="float32")
+        LM = WhittleLM(pretrained=gpt, dtype="float32", device=device)
         res = LM.loglikelihood_rolling(self.ROLLING)
         assert np.allclose(res, self.ROLLING_RES, atol=1e-1)
 
     def test_toc_encode(self, checkpoint_dir) -> None:
+        device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
         config = Config.from_file(str(checkpoint_dir / "model_config.yaml"))
         config.fix_head_size = True
         config.model_type = "gpt"
         config.tie_embeddings = False
-        gpt = GPT(config)
-        gpt.to(gpt.device)
+        gpt = GPT(config).to(device)
         gpt.name_or_path = "EleutherAI/pythia-70m"
 
         # model = LitGPT(config)
         gpt.load_state_dict(torch.load(str(checkpoint_dir / "lit_model.pth")))
-        LM = WhittleLM(pretrained=gpt, dtype="float32")
+        LM = WhittleLM(pretrained=gpt, dtype="float32", device=device)
         res = LM.tok_encode(self.TEST_STRING)
         assert res == [12110, 2534]
 
     def test_toc_decode(self, checkpoint_dir) -> None:
+        device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
         config = Config.from_file(str(checkpoint_dir / "model_config.yaml"))
         config.fix_head_size = True
         config.model_type = "gpt"
         config.tie_embeddings = False
-        gpt = GPT(config)
-        gpt.to(gpt.device)
+        gpt = GPT(config).to(device)
         gpt.name_or_path = "EleutherAI/pythia-70m"
 
         # model = LitGPT(config)
         gpt.load_state_dict(torch.load(str(checkpoint_dir / "lit_model.pth")))
-        LM = WhittleLM(pretrained=gpt, dtype="float32")
+        LM = WhittleLM(pretrained=gpt, dtype="float32", device=device)
         res = LM.tok_decode([12110, 2534])
         assert res == self.TEST_STRING
 
     def test_batch_encode(self, checkpoint_dir) -> None:
+        device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
         config = Config.from_file(str(checkpoint_dir / "model_config.yaml"))
         config.fix_head_size = True
         config.model_type = "gpt"
         config.tie_embeddings = False
-        gpt = GPT(config)
-        gpt.to(gpt.device)
+        gpt = GPT(config).to(device)
         gpt.name_or_path = "EleutherAI/pythia-70m"
 
         # model = LitGPT(config)
         gpt.load_state_dict(torch.load(str(checkpoint_dir / "lit_model.pth")))
-        LM = WhittleLM(pretrained=gpt, dtype="float32")
+        LM = WhittleLM(pretrained=gpt, dtype="float32", device=device)
         res = LM.tok_batch_encode([self.TEST_STRING, "bar foo"])[0].tolist()
         assert res == [[12110, 2534], [2009, 17374]]
 
     def test_model_generate(self, checkpoint_dir) -> None:
+        device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
         config = Config.from_file(str(checkpoint_dir / "model_config.yaml"))
         config.fix_head_size = True
         config.model_type = "gpt"
         config.tie_embeddings = False
-        gpt = GPT(config)
-        gpt.to(gpt.device)
+        gpt = GPT(config).to(device)
         gpt.name_or_path = "EleutherAI/pythia-70m"
 
         # model = LitGPT(config)
         gpt.load_state_dict(torch.load(str(checkpoint_dir / "lit_model.pth")))
-        LM = WhittleLM(pretrained=gpt, dtype="float32")
-        context = LM.tok_batch_encode([self.TEST_STRING])[0]
-        res = LM._model_generate(context.to(gpt.device), max_length=10, stop=["\n\n"])
+        LM = WhittleLM(pretrained=gpt, dtype="float32", device=device)
+        context = LM.tok_batch_encode([self.TEST_STRING])[0].to(device)
+        res = LM._model_generate(context, max_length=10, stop=["\n\n"])
         res = LM.tok_decode(res[0])
-        assert res == "foo bar\n<bazhang> !info bar"
+        assert res == "foo bar\n<bazhang>!info bar"
 
     def test_evaluate(self, checkpoint_dir, out_dir):
+        device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
         config = Config.from_file(str(checkpoint_dir / "model_config.yaml"))
         config.fix_head_size = True
         config.model_type = "gpt"
         config.tie_embeddings = False
-        gpt = GPT(config)
-        gpt.to(gpt.device)
+        gpt = GPT(config).to(device)
         gpt.name_or_path = "EleutherAI/pythia-70m"
 
         # model = LitGPT(config)
@@ -299,7 +299,7 @@ class Test_WhittleLM:
         convert_and_evaluate(
             gpt,
             out_dir=out_dir,
-            device="cpu",
+            device=str(device),
             dtype=torch.float32,
             limit=10,
             tasks="logiqa",
@@ -313,7 +313,7 @@ class Test_WhittleLM:
         module.convert_and_evaluate(
             checkpoint_dir,
             out_dir=out_dir,
-            device="cpu",
+            device=str(device),
             dtype=torch.float32,
             limit=10,
             tasks="logiqa",
@@ -329,20 +329,19 @@ class Test_WhittleLM:
 
     def test_compare_litgpt(self, checkpoint_dir, checkpoint_dir_14m, out_dir):
         torch.manual_seed(0)
+        device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
         config = Config.from_file(str(checkpoint_dir / "model_config.yaml"))
         config.fix_head_size = True
         config.model_type = "gpt"
         config.tie_embeddings = False
-        gpt = GPT(config)
-        gpt.to(gpt.device)
+        gpt = GPT(config).to(device)
         gpt.name_or_path = "EleutherAI/pythia-70m"
         gpt.load_state_dict(torch.load(str(checkpoint_dir / "lit_model.pth")))
         config_14m = Config.from_file(str(checkpoint_dir_14m / "model_config.yaml"))
         config_14m.fix_head_size = True
         config_14m.model_type = "gpt"
         config_14m.tie_embeddings = False
-        gpt_14m = GPT(config_14m)
-        gpt_14m.to(gpt_14m.device)
+        gpt_14m = GPT(config_14m).to(device)
         gpt_14m.name_or_path = "EleutherAI/pythia-14m"
         gpt_14m.load_state_dict(torch.load(str(checkpoint_dir_14m / "lit_model.pth")))
         gpt = copy_subnetwork_weights(gpt_14m, gpt)
@@ -359,7 +358,7 @@ class Test_WhittleLM:
         convert_and_evaluate(
             gpt,
             out_dir=out_dir,
-            device="cpu",
+            device=str(device),
             dtype=torch.float32,
             limit=10,
             tasks="logiqa",
@@ -373,7 +372,7 @@ class Test_WhittleLM:
         module.convert_and_evaluate(
             checkpoint_dir_14m,
             out_dir=out_dir,
-            device="cpu",
+            device=str(device),
             dtype=torch.float32,
             limit=10,
             tasks="logiqa",

--- a/test/test_training_strategies.py
+++ b/test/test_training_strategies.py
@@ -63,14 +63,16 @@ class MLP(nn.Module):
 
 @pytest.mark.parametrize("strategy", methods)
 def test_integration_training_strategies_mlp(strategy):
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+
     update_op = strategy(
         sampler=sampler_mlp,
         loss_function=loss_function,
-        device="cpu",
+        device=device,
         total_number_of_steps=1,
     )
 
-    model = MLP(5)
+    model = MLP(5).to(device)
     inputs = torch.rand((8, 5))
     outputs = torch.rand((8, 1))
     loss = update_op(model, inputs, outputs)
@@ -80,11 +82,13 @@ def test_integration_training_strategies_mlp(strategy):
 @pytest.mark.parametrize("strategy", methods)
 @pytest.mark.parametrize("kd_loss", [None, DistillLoss(0.5, 0.5)])
 def test_integration_training_strategies_gpt(strategy, kd_loss):
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+
     update_op = strategy(
         sampler=sampler_gpt,
         loss_function=torch.nn.CrossEntropyLoss(),
         kd_loss=kd_loss,
-        device="cpu",
+        device=device,
         total_number_of_steps=1,
     )
 
@@ -103,7 +107,7 @@ def test_integration_training_strategies_gpt(strategy, kd_loss):
     config.norm_eps = 1e-5
     config.lm_head_bias = True
     config.fix_head_size = True
-    gpt = GPT(config)
+    gpt = GPT(config).to(device)
     inputs = torch.randint(0, 128, (1, 128))
     outputs = torch.randn([1, 128, 128])
     loss = update_op(gpt, inputs, outputs)

--- a/test/test_training_strategies.py
+++ b/test/test_training_strategies.py
@@ -73,8 +73,8 @@ def test_integration_training_strategies_mlp(strategy):
     )
 
     model = MLP(5).to(device)
-    inputs = torch.rand((8, 5))
-    outputs = torch.rand((8, 1))
+    inputs = torch.rand((8, 5)).to(device)
+    outputs = torch.rand((8, 1)).to(device)
     loss = update_op(model, inputs, outputs)
     assert isinstance(loss, float)
 
@@ -108,7 +108,7 @@ def test_integration_training_strategies_gpt(strategy, kd_loss):
     config.lm_head_bias = True
     config.fix_head_size = True
     gpt = GPT(config).to(device)
-    inputs = torch.randint(0, 128, (1, 128))
-    outputs = torch.randn([1, 128, 128])
+    inputs = torch.randint(0, 128, (1, 128)).to(device)
+    outputs = torch.randn([1, 128, 128]).to(device)
     loss = update_op(gpt, inputs, outputs)
     assert isinstance(loss, float)

--- a/whittle/eval/whittle_llms.py
+++ b/whittle/eval/whittle_llms.py
@@ -154,7 +154,7 @@ class WhittleLM(TemplateLM):
         )
         assert not parallelize, "`parallelize=True` is not compatible with passing pre-initialized model to `pretrained`"
         self._model = pretrained
-        self._device = self._model.device
+        self._device = device
         self._config = self._model.config
 
         if tokenizer:

--- a/whittle/models/gpt/model.py
+++ b/whittle/models/gpt/model.py
@@ -27,7 +27,6 @@ class GPT(nn.Module):
         super().__init__()
         assert config.padded_vocab_size is not None
         self.config = config
-        self.device = "cuda" if torch.cuda.is_available() else "cpu"
         self.lm_head = Linear(
             config.n_embd, config.padded_vocab_size, bias=config.lm_head_bias
         )
@@ -255,7 +254,7 @@ class GPT(nn.Module):
                             self.config.rotary_percentage
                             * (self.sub_network_n_embd // self.sub_network_num_heads[i])
                         ),
-                        device=self.device,
+                        device=self.cos.device,
                     )
                 else:
                     cos, sin = self.rope_cache(
@@ -264,7 +263,7 @@ class GPT(nn.Module):
                             self.config.rotary_percentage
                             * (self.sub_network_n_embd // self.sub_network_num_heads)
                         ),
-                        device=self.device,
+                        device=self.cos.device,
                     )
             else:
                 if self.sub_network_head_size is None:
@@ -273,7 +272,7 @@ class GPT(nn.Module):
                         n_elem=int(
                             self.config.rotary_percentage * (self.config.head_size)
                         ),
-                        device=self.device,
+                        device=self.cos.device,
                     )
                 else:
                     cos, sin = self.rope_cache(
@@ -281,7 +280,7 @@ class GPT(nn.Module):
                         n_elem=int(
                             self.config.rotary_percentage * (self.sub_network_head_size)
                         ),
-                        device=self.device,
+                        device=self.cos.device,
                     )
 
             cos, sin, mask = self.process_rope_cache(cos, sin, input_pos, T)


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

The GPT module automatically sets device to `cuda` if CUDA is available. This causes a runtime error, if we move the  model to another device via `.to(device)` after initialization, since the rope cache is still on the original device. 


#### Any other comments?

This fixes also the unit test and handle the handling of devices properly as discussed [here](https://pytorch.org/blog/pytorch-0_4_0-migration-guide/#writing-device-agnostic-code).

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.