### PR TITLE
fix: rename call function

### DIFF
--- a/whittle/training_strategies/base_strategy.py
+++ b/whittle/training_strategies/base_strategy.py
@@ -41,5 +41,5 @@ class BaseTrainingStrategy:
                     "KD Loss not yet supported: Expected torch.nn.CrossEntropyLoss"
                 )
 
-    def update(self, **kwargs):
+    def __call__(self, model, inputs, outputs, **kwargs):
         raise NotImplementedError


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Renames `update` to `__call__` , which all our training strategies actually implement.



---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.