### PR TITLE
feat: add support for LLamaMLP in extract_sub_network

### DIFF
--- a/test/test_extract.py
+++ b/test/test_extract.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import torch
 from litgpt.config import Config
 
@@ -22,6 +23,44 @@ def test_extract_sub_network() -> None:
         * sub_network_config.n_layer,
         sub_network_num_heads=[sub_network_config.n_head] * sub_network_config.n_layer,
         sub_network_n_layers=sub_network_config.n_layer,
+    )
+
+    # instantiate a new model
+    sub_network = extract_sub_network(super_network, sub_network_config)
+    sub_network.eval()
+    input = torch.randint(0, 512, (1, 20))
+    out_super_net = super_network(input).detach()
+    out_sub_net = sub_network(input).detach()
+    assert torch.all(
+        torch.round(out_sub_net, decimals=9) == torch.round(out_super_net, decimals=9)
+    )
+
+
+def test_extract_sub_network_llamamlp() -> None:
+    config = Config.from_name("micro-llama-300M")
+    config.fix_head_size = False
+
+    super_network = GPT(config)
+    sub_network_config = copy.deepcopy(config)
+
+    # simulate a smaller network
+    sub_network_config.n_embd = 128
+    sub_network_config.intermediate_size = 1024
+    sub_network_config.n_layer = 6
+    sub_network_config.n_head = 4
+
+    super_network.eval()
+    super_network.set_sub_network(
+        sub_network_n_embd=sub_network_config.n_embd,
+        sub_network_intermediate_size=[sub_network_config.intermediate_size]
+        * sub_network_config.n_layer,
+        sub_network_num_heads=[sub_network_config.n_head] * sub_network_config.n_layer,
+        sub_network_n_layers=sub_network_config.n_layer,
+    )
+
+    # dynamically computed when set_sub_network is called
+    sub_network_config.head_size = (
+        sub_network_config.n_embd // sub_network_config.n_head
     )
 
     # instantiate a new model

--- a/whittle/models/gpt/extract.py
+++ b/whittle/models/gpt/extract.py
@@ -49,7 +49,7 @@ def extract_mlp(mlp, sub_mlp):
         sub_mlp.proj.load_state_dict(state_dict)
     else:
         raise ValueError(
-            "Cannot extract MLP, supported MLP classes are GptNeoxMLP and LLaMAMLP."
+            "Cannot extract MLP, supported MLP classes are GptNeoxMLP, LLaMAMLP and GemmaMLP."
         )
 
 


### PR DESCRIPTION
#### Reference Issues/PRs
https://github.com/whittle-org/whittle/issues/139

#### What does this implement/fix? Explain your changes.
Extract sub-network worked only for GPTNeoxMLP, but not for LLamaMLP. I added a function that check for both cases and raises a ValueError if a different MLP class is used.

#### Minimal Example / How should this PR be tested?
We should include a test to `test_extract.py` - similar to extracting a smaller `pythia`, but with LLamaMLP

#### Any other comments?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.