### PR TITLE
ci: switching to `uv` for github actions

### DIFF
--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           version: latest
           enable-cache: true
+          cache-dependency-glob: "**/pyproject.toml"
       - name: create virtual environment
         run: uv venv --python ${{ matrix.python-version }}
       - name: Install

--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -20,6 +20,7 @@ jobs:
         uses: astral-sh/setup-uv@v3
         with:
           version: latest
+          enable-cache: true
       - name: create virtual environment
         run: uv venv --python ${{ matrix.python-version }}
       - name: Install

--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -13,17 +13,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Run in all these versions of Python
-        python-version: [ "3.11" ]
+        python-version: ["3.11"]
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+      - name: install the latest version uv
+        uses: astral-sh/setup-uv@v3
         with:
-          python-version: ${{ matrix.python-version }}
-          cache: 'pip'
+          version: latest
+      - name: create virtual environment
+        run: uv venv --python ${{ matrix.python-version }}
       - name: Install
-        run: pip install .
+        run: uv pip install ".[dev]"
       - name: Run sine curves example
         run: |
           python -m examples.sine_curves.sinc_nas

--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -26,9 +26,9 @@ jobs:
         run: uv pip install ".[dev]"
       - name: Run sine curves example
         run: |
-          python -m examples.sine_curves.sinc_nas
-          python -m examples.sine_curves.search
+          uv run python -m examples.sine_curves.sinc_nas
+          uv run python -m examples.sine_curves.search
       - name: Run fashion MNIST example
         run: |
-          python -m examples.fashion_mnist.train_fashion_mnist
-          python -m examples.fashion_mnist.search_fashion_mnist
+          uv run python -m examples.fashion_mnist.train_fashion_mnist
+          uv run python -m examples.fashion_mnist.search_fashion_mnist

--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -20,8 +20,6 @@ jobs:
         uses: astral-sh/setup-uv@v3
         with:
           version: latest
-          enable-cache: true
-          cache-dependency-glob: "**/pyproject.toml"
       - name: create virtual environment
         run: uv venv --python ${{ matrix.python-version }}
       - name: Install

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -12,7 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Run in all these versions of Python
         python-version: ["3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v4
@@ -20,8 +19,6 @@ jobs:
         uses: astral-sh/setup-uv@v3
         with:
           version: latest
-      # - name: Set up Python ${{ matrix.python-version }}
-      #   run: uv python install ${{ matrix.python-version }}
       - name: create virtual environment
         run: uv venv --python ${{ matrix.python-version }}
       - name: Install

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           version: latest
           enable-cache: true
+          cache-dependency-glob: "**/pyproject.toml"
       - name: create virtual environment
         run: uv venv --python ${{ matrix.python-version }}
       - name: Install

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -3,6 +3,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 on:
+  workflow_dispatch:
   push:
     branches: [ main ]
   pull_request:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -20,8 +20,10 @@ jobs:
         uses: astral-sh/setup-uv@v3
         with:
           version: latest
-      - name: Set up Python ${{ matrix.python-version }}
-        run: uv python install ${{ matrix.python-version }}
+      # - name: Set up Python ${{ matrix.python-version }}
+      #   run: uv python install ${{ matrix.python-version }}
+      - name: create virtual environment
+        run: uv venv --python ${{ matrix.python-version }}
       - name: Install
         run: uv pip install ".[dev]"
       - name: Run pytest

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -27,4 +27,4 @@ jobs:
       - name: Install
         run: uv pip install ".[dev]"
       - name: Run pytest
-        run: uv pytest -vvv
+        run: uv run pytest -vvv

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -19,6 +19,7 @@ jobs:
         uses: astral-sh/setup-uv@v3
         with:
           version: latest
+          enable-cache: true
       - name: create virtual environment
         run: uv venv --python ${{ matrix.python-version }}
       - name: Install

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -20,8 +20,6 @@ jobs:
         uses: astral-sh/setup-uv@v3
         with:
           version: latest
-          enable-cache: true
-          cache-dependency-glob: "**/pyproject.toml"
       - name: create virtual environment
         run: uv venv --python ${{ matrix.python-version }}
       - name: Install

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -16,12 +16,13 @@ jobs:
         python-version: ["3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+      - name: install the latest version uv
+        uses: astral-sh/setup-uv@v3
         with:
-          python-version: ${{ matrix.python-version }}
-          cache: 'pip'
+          version: latest
+      - name: Set up Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
       - name: Install
-        run: pip install ".[dev]"
+        run: uv pip install ".[dev]"
       - name: Run pytest
-        run: pytest -vvv
+        run: uv pytest -vvv


### PR DESCRIPTION
this pr switches our `run-examples` and `unit-test` github actions workflows to use `astral-sh/setup-uv` instead of `actions/setup-python`. This cuts the time needed for each workflow roughly in half (~6 mins to ~3 mins)

Closes #148 