### PR TITLE
fix: Extract weights for norm layers, test with random initialization.

### DIFF
--- a/test/test_extract.py
+++ b/test/test_extract.py
@@ -105,4 +105,3 @@ def make_norm_weights_random(norm):
     torch.nn.init.normal_(norm.weight)
     if isinstance(norm, LayerNorm):
         torch.nn.init.normal_(norm.bias)
-

--- a/test/test_extract.py
+++ b/test/test_extract.py
@@ -6,6 +6,8 @@ from litgpt.config import Config
 
 from whittle.models.gpt import GPT
 from whittle.models.gpt.extract import extract_sub_network
+from whittle.modules.rmsnorm import RMSNorm
+from whittle.modules.layernorm import LayerNorm
 
 
 def test_extract_sub_network() -> None:
@@ -15,6 +17,16 @@ def test_extract_sub_network() -> None:
     super_network = GPT(config)
     sub_network_config = Config.from_name("pythia-14m")
     sub_network_config.fix_head_size = False
+
+    # set norm weights to random
+    # the default is unit/zero vector which does not test the extract
+    make_norm_weights_random(super_network.transformer.ln_f)
+    for i in range(sub_network_config.n_layer):
+        block = super_network.transformer.h[i]
+        make_norm_weights_random(block.norm_1)
+        make_norm_weights_random(block.post_attention_norm)
+        make_norm_weights_random(block.norm_2)
+        make_norm_weights_random(block.post_mlp_norm)
 
     super_network.eval()
     super_network.set_sub_network(
@@ -42,6 +54,16 @@ def test_extract_sub_network_llamamlp() -> None:
 
     super_network = GPT(config)
     sub_network_config = copy.deepcopy(config)
+
+    # set norm weights to random
+    # the default is unit/zero vector which does not test the extract
+    make_norm_weights_random(super_network.transformer.ln_f)
+    for i in range(sub_network_config.n_layer):
+        block = super_network.transformer.h[i]
+        make_norm_weights_random(block.norm_1)
+        make_norm_weights_random(block.post_attention_norm)
+        make_norm_weights_random(block.norm_2)
+        make_norm_weights_random(block.post_mlp_norm)
 
     # simulate a smaller network
     sub_network_config.n_embd = 128
@@ -72,3 +94,15 @@ def test_extract_sub_network_llamamlp() -> None:
     assert torch.all(
         torch.round(out_sub_net, decimals=9) == torch.round(out_super_net, decimals=9)
     )
+
+
+def make_norm_weights_random(norm):
+    if norm is None or isinstance(norm, torch.nn.Identity):
+        return
+
+    assert isinstance(norm, RMSNorm) or isinstance(norm, LayerNorm)
+
+    torch.nn.init.normal_(norm.weight)
+    if isinstance(norm, LayerNorm):
+        torch.nn.init.normal_(norm.bias)
+

--- a/whittle/models/gpt/extract.py
+++ b/whittle/models/gpt/extract.py
@@ -77,7 +77,7 @@ def extract_norm(norm, sub_norm):
 
     # extract depending on norm type
     assert isinstance(norm, RMSNorm) or isinstance(norm, LayerNorm)
-    
+
     in_feat_sub = sub_norm.in_features
     super_state = norm.state_dict()
 
@@ -93,8 +93,9 @@ def extract_norm(norm, sub_norm):
         raise ValueError(
             "Cannot extract norm, supported norm classes are RMSNorm and LayerNorm."
         )
-    
+
     sub_norm.load_state_dict(new_state_dict)
+
 
 def extract_linear(super_network_linear):
     super_network_state = super_network_linear.state_dict()

--- a/whittle/models/gpt/extract.py
+++ b/whittle/models/gpt/extract.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import torch.nn as nn
+
 from collections import OrderedDict
 
 from whittle.models.gpt import GPT
 from whittle.models.gpt.blocks.mlp import GptNeoxMLP, LLaMAMLP
+from whittle.modules.layernorm import LayerNorm
+from whittle.modules.rmsnorm import RMSNorm
 
 
 def extract_sub_network(model, sub_network_config):
@@ -14,6 +18,8 @@ def extract_sub_network(model, sub_network_config):
 
     state_dict = extract_embedding(model.transformer.wte)
     sub_network.transformer.wte.load_state_dict(state_dict)
+
+    extract_norm(model.transformer.ln_f, sub_network.transformer.ln_f)
 
     for i in range(sub_network_config.n_layer):
         block = model.transformer.h[i]
@@ -27,6 +33,12 @@ def extract_sub_network(model, sub_network_config):
 
         # MLP
         extract_mlp(block.mlp, sub_network_block.mlp)
+
+        # norm
+        extract_norm(block.norm_1, sub_network_block.norm_1)
+        extract_norm(block.post_attention_norm, sub_network_block.post_attention_norm)
+        extract_norm(block.norm_2, sub_network_block.norm_2)
+        extract_norm(block.post_mlp_norm, sub_network_block.post_mlp_norm)
 
     return sub_network
 
@@ -52,6 +64,37 @@ def extract_mlp(mlp, sub_mlp):
             "Cannot extract MLP, supported MLP classes are GptNeoxMLP, LLaMAMLP and GemmaMLP."
         )
 
+
+def extract_norm(norm, sub_norm):
+    # nothing to extract
+    if norm is None:
+        assert sub_norm is None
+        return
+
+    if isinstance(norm, nn.Identity):
+        assert isinstance(sub_norm, nn.Identity)
+        return
+
+    # extract depending on norm type
+    assert isinstance(norm, RMSNorm) or isinstance(norm, LayerNorm)
+    
+    in_feat_sub = sub_norm.in_features
+    super_state = norm.state_dict()
+
+    new_state_dict = OrderedDict()
+    new_state_dict["weight"] = super_state["weight"][:in_feat_sub]
+
+    if isinstance(norm, RMSNorm):
+        assert isinstance(sub_norm, RMSNorm)
+    elif isinstance(norm, LayerNorm):
+        assert isinstance(sub_norm, LayerNorm)
+        new_state_dict["bias"] = super_state["bias"][:in_feat_sub]
+    else:
+        raise ValueError(
+            "Cannot extract norm, supported norm classes are RMSNorm and LayerNorm."
+        )
+    
+    sub_norm.load_state_dict(new_state_dict)
 
 def extract_linear(super_network_linear):
     super_network_state = super_network_linear.state_dict()


### PR DESCRIPTION
#### Reference Issues/PRs
https://github.com/whittle-org/whittle/issues/150

#### What does this implement/fix? Explain your changes.
Extract weights from norm layers of a subnetwork. Add random init of these weights to the test, since the
default (unit/zero init) passes for uninitialized nets (even without extracting the weights).

#### Minimal Example / How should this PR be tested?
`test_extract.py`

#### Any other comments?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.