### PR TITLE
fixed type hints

### DIFF
--- a/whittle/eval/utils.py
+++ b/whittle/eval/utils.py
@@ -26,7 +26,8 @@ def prepare_results(results, save_filepath, print_results=True):
 def convert_and_evaluate(
     model: GPT,
     tasks: str | None = None,
-    out_dir=None,
+    checkpoint_dir: Path | None = None, 
+    out_dir: Path | None = None,    
     force_conversion: bool = False,
     num_fewshot: int | None = None,
     batch_size: int | str = 1,

--- a/whittle/loss/kd_loss.py
+++ b/whittle/loss/kd_loss.py
@@ -33,7 +33,8 @@ class DistillLoss(nn.Module):
         self.distillation_weight = distillation_weight
         self.kldiv = nn.KLDivLoss(reduction="batchmean")
 
-    def forward(self, outputs, labels, outputs_teacher):
+    #def forward(self, outputs, labels, outputs_teacher):
+    def forward(self, outputs, labels, outputs_teacher) -> nn.Tensor:
         """
         Compute the distillation loss.
 

--- a/whittle/metrics/mag.py
+++ b/whittle/metrics/mag.py
@@ -8,7 +8,7 @@ from whittle.models.gpt import GPT
 from whittle.models.gpt.blocks import GptNeoxMLP, GemmaMLP, LLaMAMLP
 
 
-def weight_magnitude(model: GPT):
+def weight_magnitude(model: GPT)->float:    
     """
     Computes the sum of the weight magnitudes of the current sub-network of a GPT model. Make sure to set the
     sub-network before calling this function.

--- a/whittle/metrics/parameters.py
+++ b/whittle/metrics/parameters.py
@@ -71,7 +71,7 @@ def params_mlp(mlp: nn.Module):
     return num_params
 
 
-def compute_parameters_sub_network_gpt(model: GPT):
+def compute_parameters_sub_network_gpt(model: GPT)->float:  
     """
     Computes parameters of the current sub-network of a GPT mmodel. Make sure to set the sub-network before
     calling this function.

--- a/whittle/training_strategies/ats.py
+++ b/whittle/training_strategies/ats.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from whittle.training_strategies.base_strategy import BaseTrainingStrategy
 
 
+from typing import Any, Dict
+
 class ATS(BaseTrainingStrategy):
     """
     ATS strategy.
@@ -17,7 +19,7 @@ class ATS(BaseTrainingStrategy):
         https://arxiv.org/abs/2106.08895
     """
 
-    def __init__(self, random_samples: int = 1, **kwargs):
+    def __init__(self, random_samples: int = 1,  **kwargs: Dict[str, Any]):
         """
         Initialises an `ATS` strategy.
 
@@ -29,7 +31,7 @@ class ATS(BaseTrainingStrategy):
         self.random_samples = random_samples
         self.current_step = 0
 
-    def __call__(self, model, inputs, outputs, **kwargs):
+    def __call__(self, model, inputs, outputs,  **kwargs: Dict[str, Any]):
         """
         Updates a set of randomly sampled sub-networks if the current step is odd. Else, it updates the
         super-network.

--- a/whittle/training_strategies/random.py
+++ b/whittle/training_strategies/random.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from whittle.training_strategies.base_strategy import BaseTrainingStrategy
 
+from typing import Any, Dict
 
 class RandomStrategy(BaseTrainingStrategy):
     """
@@ -10,7 +11,7 @@ class RandomStrategy(BaseTrainingStrategy):
     Randomly samples and updates `random_samples` sub-networks in each step.
     """
 
-    def __init__(self, random_samples: int = 1, **kwargs):
+    def __init__(self, random_samples: int = 1,  **kwargs: Dict[str, Any]):
         """
         Initialises a `RandomStrategy`
 

--- a/whittle/training_strategies/random_linear.py
+++ b/whittle/training_strategies/random_linear.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from whittle.training_strategies.base_strategy import BaseTrainingStrategy
 
+from typing import Any, Dict
 
 class RandomLinearStrategy(BaseTrainingStrategy):
     """
@@ -23,7 +24,7 @@ class RandomLinearStrategy(BaseTrainingStrategy):
         https://proceedings.mlr.press/v80/bender18a/bender18a.pdf
     """
 
-    def __init__(self, total_number_of_steps: int, random_samples: int = 1, **kwargs):
+    def __init__(self, total_number_of_steps: int, random_samples: int = 1, **kwargs: Dict[str, Any]):
         """
         Initialises a `RandomLinearStrategy`
 

--- a/whittle/training_strategies/sandwich.py
+++ b/whittle/training_strategies/sandwich.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from whittle.training_strategies.base_strategy import BaseTrainingStrategy
 
+from typing import Any, Dict
 
 class SandwichStrategy(BaseTrainingStrategy):
     """
@@ -17,7 +18,7 @@ class SandwichStrategy(BaseTrainingStrategy):
         https://arxiv.org/abs/1903.05134
     """
 
-    def __init__(self, random_samples: int = 2, **kwargs):
+    def __init__(self, random_samples: int = 2, **kwargs: Dict[str, Any]):
         """
         Initialises a `SandwichStrategy`
 

--- a/whittle/training_strategies/standard.py
+++ b/whittle/training_strategies/standard.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from whittle.training_strategies.base_strategy import BaseTrainingStrategy
 
+from typing import Any, Dict    
 
 class StandardStrategy(BaseTrainingStrategy):
     """
@@ -10,7 +11,7 @@ class StandardStrategy(BaseTrainingStrategy):
     Implements the standard update rule and updates all weights of the super-network.
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs: Dict[str, Any]):
         """
         Initialises a `StandardStrategy`
 


### PR DESCRIPTION
Fix type hints to make docs happy #114

I made changes such that warnings related to type hints no longer appear when running :
 ``` mkdocs build --clean --strict ```

I still have to do the second part. 

@timurcarstensen 