### PR TITLE
fix: fixed type hints

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,4 +22,4 @@ jobs:
       - name: Run mkdocs
         # You can include `--strict` to treat warnings as errors
         # Advised if you can sort out the typing issues
-        run: mkdocs build --clean
+        run: mkdocs build --clean --strict

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           python-version: "3.10"
           cache: pip
       - run: python -m pip install ".[dev]"
-      - run: mkdocs build --clean
+      - run: mkdocs build --clean --strict
   # Need to ensure we bump before we create any artifacts
   bump:
     runs-on: ubuntu-latest

--- a/whittle/eval/utils.py
+++ b/whittle/eval/utils.py
@@ -26,7 +26,7 @@ def prepare_results(results, save_filepath, print_results=True):
 def convert_and_evaluate(
     model: GPT,
     tasks: str | None = None,
-    out_dir=None,
+    out_dir: Path | str = "evaluate",
     force_conversion: bool = False,
     num_fewshot: int | None = None,
     batch_size: int | str = 1,
@@ -40,7 +40,6 @@ def convert_and_evaluate(
     """Evaluate a model with the LM Evaluation Harness.
 
     Arguments:
-        checkpoint_dir: Directory where the `lit_model.pth` and tokenizer files are located.
         out_dir: Directory in which to save the converted checkpoints for evaluation.
             Saves to `checkpoint_dir`/evaluate by default.
         force_conversion: Set to `True` to reconvert the model and override

--- a/whittle/loss/kd_loss.py
+++ b/whittle/loss/kd_loss.py
@@ -33,7 +33,7 @@ class DistillLoss(nn.Module):
         self.distillation_weight = distillation_weight
         self.kldiv = nn.KLDivLoss(reduction="batchmean")
 
-    def forward(self, outputs, labels, outputs_teacher):
+    def forward(self, outputs, labels, outputs_teacher) -> nn.Tensor:
         """
         Compute the distillation loss.
 

--- a/whittle/metrics/mag.py
+++ b/whittle/metrics/mag.py
@@ -8,7 +8,7 @@ from whittle.models.gpt import GPT
 from whittle.models.gpt.blocks import GptNeoxMLP, GemmaMLP, LLaMAMLP
 
 
-def compute_weight_magnitude(model: GPT):
+def compute_weight_magnitude(model: GPT) -> float:
     """
     Computes the sum of the weight magnitudes of the current sub-network of a GPT model. Make sure to set the
     sub-network before calling this function.

--- a/whittle/metrics/parameters.py
+++ b/whittle/metrics/parameters.py
@@ -71,7 +71,7 @@ def params_mlp(mlp: nn.Module):
     return num_params
 
 
-def compute_parameters(model: GPT):
+def compute_parameters(model: GPT) -> float:
     """
     Computes parameters of the current sub-network of a GPT mmodel. Make sure to set the sub-network before
     calling this function.

--- a/whittle/models/gpt/utils.py
+++ b/whittle/models/gpt/utils.py
@@ -400,6 +400,7 @@ class CycleIterator:
     Example:
         >>> iterator = CycleIterator([1, 2, 3])
         >>> [next(iterator) for _ in range(5)]
+
         [1, 2, 3, 1, 2]
 
     Note:

--- a/whittle/training_strategies/ats.py
+++ b/whittle/training_strategies/ats.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from whittle.training_strategies.base_strategy import BaseTrainingStrategy
-
 from typing import Any
+
+from whittle.training_strategies.base_strategy import BaseTrainingStrategy
 
 
 class ATS(BaseTrainingStrategy):

--- a/whittle/training_strategies/ats.py
+++ b/whittle/training_strategies/ats.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from whittle.training_strategies.base_strategy import BaseTrainingStrategy
 
+from typing import Any
+
 
 class ATS(BaseTrainingStrategy):
     """
@@ -17,7 +19,7 @@ class ATS(BaseTrainingStrategy):
         https://arxiv.org/abs/2106.08895
     """
 
-    def __init__(self, random_samples: int = 1, **kwargs):
+    def __init__(self, random_samples: int = 1, **kwargs: Any):
         """
         Initialises an `ATS` strategy.
 

--- a/whittle/training_strategies/random.py
+++ b/whittle/training_strategies/random.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from whittle.training_strategies.base_strategy import BaseTrainingStrategy
 
+from typing import Any
+
 
 class RandomStrategy(BaseTrainingStrategy):
     """
@@ -10,7 +12,7 @@ class RandomStrategy(BaseTrainingStrategy):
     Randomly samples and updates `random_samples` sub-networks in each step.
     """
 
-    def __init__(self, random_samples: int = 1, **kwargs):
+    def __init__(self, random_samples: int = 1, **kwargs: Any):
         """
         Initialises a `RandomStrategy`
 

--- a/whittle/training_strategies/random.py
+++ b/whittle/training_strategies/random.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from whittle.training_strategies.base_strategy import BaseTrainingStrategy
-
 from typing import Any
+
+from whittle.training_strategies.base_strategy import BaseTrainingStrategy
 
 
 class RandomStrategy(BaseTrainingStrategy):

--- a/whittle/training_strategies/random_linear.py
+++ b/whittle/training_strategies/random_linear.py
@@ -4,6 +4,8 @@ import numpy as np
 
 from whittle.training_strategies.base_strategy import BaseTrainingStrategy
 
+from typing import Any
+
 
 class RandomLinearStrategy(BaseTrainingStrategy):
     """
@@ -23,7 +25,9 @@ class RandomLinearStrategy(BaseTrainingStrategy):
         https://proceedings.mlr.press/v80/bender18a/bender18a.pdf
     """
 
-    def __init__(self, total_number_of_steps: int, random_samples: int = 1, **kwargs):
+    def __init__(
+        self, total_number_of_steps: int, random_samples: int = 1, **kwargs: Any
+    ):
         """
         Initialises a `RandomLinearStrategy`
 

--- a/whittle/training_strategies/random_linear.py
+++ b/whittle/training_strategies/random_linear.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
+from typing import Any
 import numpy as np
 
 from whittle.training_strategies.base_strategy import BaseTrainingStrategy
-
-from typing import Any
 
 
 class RandomLinearStrategy(BaseTrainingStrategy):

--- a/whittle/training_strategies/sandwich.py
+++ b/whittle/training_strategies/sandwich.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from whittle.training_strategies.base_strategy import BaseTrainingStrategy
 
+from typing import Any
+
 
 class SandwichStrategy(BaseTrainingStrategy):
     """
@@ -17,7 +19,7 @@ class SandwichStrategy(BaseTrainingStrategy):
         https://arxiv.org/abs/1903.05134
     """
 
-    def __init__(self, random_samples: int = 2, **kwargs):
+    def __init__(self, random_samples: int = 2, **kwargs: Any):
         """
         Initialises a `SandwichStrategy`
 

--- a/whittle/training_strategies/sandwich.py
+++ b/whittle/training_strategies/sandwich.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from whittle.training_strategies.base_strategy import BaseTrainingStrategy
-
 from typing import Any
+
+from whittle.training_strategies.base_strategy import BaseTrainingStrategy
 
 
 class SandwichStrategy(BaseTrainingStrategy):

--- a/whittle/training_strategies/standard.py
+++ b/whittle/training_strategies/standard.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from whittle.training_strategies.base_strategy import BaseTrainingStrategy
-
 from typing import Any
+
+from whittle.training_strategies.base_strategy import BaseTrainingStrategy
 
 
 class StandardStrategy(BaseTrainingStrategy):

--- a/whittle/training_strategies/standard.py
+++ b/whittle/training_strategies/standard.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from whittle.training_strategies.base_strategy import BaseTrainingStrategy
 
+from typing import Any
+
 
 class StandardStrategy(BaseTrainingStrategy):
     """
@@ -10,7 +12,7 @@ class StandardStrategy(BaseTrainingStrategy):
     Implements the standard update rule and updates all weights of the super-network.
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs: Any):
         """
         Initialises a `StandardStrategy`
 


### PR DESCRIPTION
Reference Issues/PRs

removes warnings when running  ```mkdocs build --clean --strict```