### PR TITLE
fix: set input variables as required positional arguments

### DIFF
--- a/whittle/models/gpt/blocks/causal_self_attention.py
+++ b/whittle/models/gpt/blocks/causal_self_attention.py
@@ -45,8 +45,8 @@ class CausalSelfAttention(nn.Module):
         self,
         sub_network_n_embd: int,
         sub_network_n_head: int,
-        sub_network_query_groups=None,
-        sub_network_head_size=None,
+        sub_network_query_groups: int,
+        sub_network_head_size: int,
     ):
         self.sub_network_n_embd = sub_network_n_embd
         self.sub_network_n_head = sub_network_n_head

--- a/whittle/models/gpt/blocks/transformer_block.py
+++ b/whittle/models/gpt/blocks/transformer_block.py
@@ -66,8 +66,8 @@ class Block(litgpt.model.Block):
         sub_network_n_embd: int,
         sub_network_intermediate_size: int,
         sub_network_num_heads: int,
-        sub_network_query_groups=None,
-        sub_network_head_size=None,
+        sub_network_query_groups: int,
+        sub_network_head_size: int,
     ) -> None:
         self.sub_network_n_embd = sub_network_n_embd
         self.sub_network_intermediate_size = sub_network_intermediate_size


### PR DESCRIPTION
#### Reference Issues/PRs
#165 
#### What does this implement/fix? Explain your changes.
input variables in set_sub_network are now required as input to avoid the function from crashing.
