### PR TITLE
ci: add python 3.12 support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         # Run in all these versions of Python
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
       - name: install the latest version uv

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
       - name: install the latest version uv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [{name = "Aaron Klein"},
     {name = "Timur Carstensen"}]
 license = { file = "LICENSE" }
 readme = "README.md"
-requires-python = ">=3.9,<3.12"
+requires-python = ">=3.9,<3.13"
 # TODO: Some of these might be able to be moved to optional dependancies
 dependencies = [
   "pandas",


### PR DESCRIPTION
#### Reference Issues/PRs
Closes #166

#### What does this implement/fix? Explain your changes.
This PR adds support for Python 3.12 by updating the GitHub Actions workflows (`unit-test.yml`, `run-examples.yml`, `pyproject.toml` and `release.yml`). This includes adding Python 3.12 to the testing matrix, ensuring compatibility across supported Python versions.

#### Minimal Example / How should this PR be tested?

#### Any other comments?
All tests have been verified to pass for Python 3.12 locally, with minor warnings noted from external dependencies (such as Pydantic and PyTorch) due to Python 3.12's stricter deprecation tracking. These do not affect functionality.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.