### PR TITLE
fix: colab tutorial notebook and typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 ```bash
 # Create your own fork of the repository if required and replace whittle-org with your username
-git clone git@github.com/whittle-org/whittle.git
+git clone git@github.com:whittle-org/whittle.git
 cd whittle
 pip install -e ".[dev]"  # Install what's here (the `.` part) and install the extra dev dependancies
 ```

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ pip install -e .
 ```
 ### Getting started with whittle  
 
-To explore and understand different functionalities of ```whittle``` checkout [this](https://colab.research.google.com/drive/1xFhsHrqJGQnFuigLCqKHsJFLsJwksl4v?usp=sharing) colab notebook and ```examples/```
+To explore and understand different functionalities of ```whittle``` checkout [this](https://colab.research.google.com/drive/1i_FjIf_qCTJFcp0emOHX9E6I6j6kkIcH?usp=sharing) colab notebook and ```examples/```
 
 ## Projects that use whittle
 


### PR DESCRIPTION
updated colab tutorial notebook and git command to clone directory

#### Reference Issues/PRs
none
#### What does this implement/fix? Explain your changes.
README.md - added link to a new colab tutorial notebook that is aligned with the updates in the API 
CONTRIBUTING.md - git command to clone directory had a typo

#### Minimal Example / How should this PR be tested?
none
#### Any other comments?
none

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.