### PR TITLE
fix: fix dependency versions to avoid breaking CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
   "torch>=2",
   "transformers==4.43.1",
   "litgpt[all]==0.5.0",
-  "syne-tune[moo]>=0.13",
+  "git+https://github.com/syne-tune/syne-tune.git",
   "torchvision>=0.18",
   "deepspeed"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
   "matplotlib",
   "typing-extensions",
   "torch>=2",
-  "transformers>=4",
+  "transformers==4.43.1",
   "litgpt[all]==0.5.0",
   "syne-tune[moo]>=0.13",
   "torchvision>=0.18",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,10 @@ dependencies = [
   "torch>=2",
   "transformers==4.43.1",
   "litgpt[all]==0.5.0",
-  "git+https://github.com/syne-tune/syne-tune.git",
+  "syne-tune[moo]>=0.13",
   "torchvision>=0.18",
+  "boto3==1.34.147",
+  "botocore==1.34.147",
   "deepspeed"
 ]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
   "matplotlib",
   "typing-extensions",
   "torch>=2",
-  "transformers==4.43.1",
+  "transformers>=4",
   "litgpt[all]==0.5.0",
   "syne-tune[moo]>=0.13",
   "torchvision>=0.18",


### PR DESCRIPTION
Current CI fails because of latest `boto3` version which is currently required for Syne Tune. I suggest we put it in here but will remove it again with the next release of Syne Tune.


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.