### PR TITLE
Fix: Enable to extract the current subnet.

### DIFF
--- a/whittle/models/gpt/extract.py
+++ b/whittle/models/gpt/extract.py
@@ -4,12 +4,38 @@ from __future__ import annotations
 import torch.nn as nn
 
 from collections import OrderedDict
+from copy import deepcopy
 
 from whittle.models.gpt import GPT
 from whittle.models.gpt.blocks.mlp import GptNeoxMLP, LLaMAMLP
 from whittle.modules.layernorm import LayerNorm
 from whittle.modules.rmsnorm import RMSNorm
 from litgpt import Config
+
+
+def extract_current_sub_network(model: GPT):
+    """
+    Extracts the current sub-network of the super-network model.
+    The sub-network is set by calling `set_sub_network` or `select_sub_network`. This function
+    creates a new super-network model with the same configuration and parameters as the sub-network.
+
+    Args:
+        model: The original, full GPT super-network model from which the active sub-network is extracted.
+
+    Returns:
+        A new super-network model instance, initialized with parameters extracted from the original model.
+    """
+    subnet_config = deepcopy(model.config)
+
+    subnet_config.n_embd = model.sub_network_n_embd
+    subnet_config.intermediate_size = model.sub_network_intermediate_size
+    subnet_config.n_head = model.sub_network_num_heads
+    subnet_config.n_layer = model.sub_network_n_layers
+    subnet_config.head_size = model.sub_network_head_size
+    subnet_config.n_query_groups = model.sub_network_query_groups
+    subnet_config.rope_n_elem = model.sub_network_rope_n_elem
+
+    return extract_sub_network(model, subnet_config)
 
 
 def extract_sub_network(model: GPT, sub_network_config: Config) -> GPT:


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes https://github.com/whittle-org/whittle/issues/178

#### What does this implement/fix? Explain your changes.
We can extract the current active subnetwork instead of passing around configs/dicts.

I feel like 

#### Minimal Example / How should this PR be tested?
I modified the llama mlp test - now the active subnet is extracted instead of setting fields in a config.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.