### PR TITLE
fix: Reset the rope cache in reset_super_network

### DIFF
--- a/whittle/models/gpt/model.py
+++ b/whittle/models/gpt/model.py
@@ -102,7 +102,7 @@ class GPT(nn.Module):
         # Trigger resetting the rope-cache
         self.cos, self.sin = self.rope_cache(
             seq_len=self._max_seq_length,
-            n_elem=self.config.rope_n_elem,
+            n_elem=self.sub_network_rope_n_elem,
             device=self.cos.device,
         )
 

--- a/whittle/models/gpt/model.py
+++ b/whittle/models/gpt/model.py
@@ -258,6 +258,8 @@ class GPT(nn.Module):
         """
         Resets the GPT model to the original super-network dimensionality.
         """
+        rebuild_rope = self.sub_network_rope_n_elem != self.config.rope_n_elem
+
         self.sub_network_n_embd = self.config.n_embd
         self.sub_network_intermediate_size = self.config.intermediate_size
         self.sub_network_num_heads = self.config.n_head
@@ -271,6 +273,10 @@ class GPT(nn.Module):
             block = self.transformer.h[i]
             block.reset_super_network()
         self.lm_head.reset_super_network()
+
+        # rebuild the rope cache
+        if rebuild_rope:
+            self.reset_parameters()
 
     def process_rope_cache(self, cos, sin, input_pos, T):
         if input_pos is not None:  # use the kv cache


### PR DESCRIPTION
`self.cos` and `self.sin` were not reset when calling `reset_super_network` - fixed

#### Reference Issues/PRs
https://github.com/whittle-org/whittle/issues/216

#### What does this implement/fix? Explain your changes.

#### Minimal Example / How should this PR be tested?

#### Any other comments?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.