### PR TITLE
feat: fix `triton` version to `3.0.0` 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,41 +2,42 @@
 name = "whittle"
 version = "0.4.1"
 description = "Two-stage neural architecture search for large language models"
-authors = [{name = "Aaron Klein"},
-    {name = "Arber Zela"},
-    {name = "Rhea Sukthanker"},
-    {name = "Timur Carstensen"}]
+authors = [
+    { name = "Aaron Klein" },
+    { name = "Arber Zela" },
+    { name = "Rhea Sukthanker" },
+    { name = "Timur Carstensen" },
+]
 license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.9,<3.13"
 # TODO: Some of these might be able to be moved to optional dependancies
 dependencies = [
-  "pandas",
-  "matplotlib",
-  "typing-extensions",
-  "torch>=2",
-  "transformers>=4",
-  "litgpt[all]==0.5.0",
-  "syne-tune[moo]>=0.13",
-  "torchvision>=0.18",
-  "boto3==1.34.147",
-  "botocore==1.34.147",
-  "deepspeed"
+    "pandas",
+    "matplotlib",
+    "typing-extensions",
+    "torch>=2",
+    "transformers>=4",
+    "litgpt[all]==0.5.0",
+    "syne-tune[moo]>=0.13",
+    "torchvision>=0.18",
+    "boto3==1.34.147",
+    "botocore==1.34.147",
 ]
 classifiers = [
-  "Intended Audience :: Science/Research",
-  "Intended Audience :: Developers",
-  "License :: OSI Approved :: Apache Software License",
-  "Programming Language :: Python",
-  "Topic :: Software Development",
-  "Topic :: Scientific/Engineering",
-  "Operating System :: POSIX",
-  "Operating System :: Unix",
-  "Operating System :: MacOS",
-  "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
-  "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11",
+    "Intended Audience :: Science/Research",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python",
+    "Topic :: Software Development",
+    "Topic :: Scientific/Engineering",
+    "Operating System :: POSIX",
+    "Operating System :: Unix",
+    "Operating System :: MacOS",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
 ]
 
 [project.urls]
@@ -45,37 +46,32 @@ homepage = "https://github.com/whittle-org/whittle"
 
 [project.optional-dependencies]
 dev = [
-  # -- deploy --
-  "build",
-  # -- ci --
-  "pre-commit",
-  "pytest>=8",
-  "ruff",
-  "mypy",
-  "commitizen",
-  # -- docs --
-  "mike",
-  "mkdocs",
-  "mkdocs-material",
-  "mkdocs-autorefs",
-  "mkdocs-gen-files",
-  "mkdocs-literate-nav",
-  "mkdocstrings[python]",
-  "black",  # Allows mkdocstrings to do formatting...
+    # -- deploy --
+    "build",
+    # -- ci --
+    "pre-commit",
+    "pytest>=8",
+    "ruff",
+    "mypy",
+    "commitizen",
+    # -- docs --
+    "mike",
+    "mkdocs",
+    "mkdocs-material",
+    "mkdocs-autorefs",
+    "mkdocs-gen-files",
+    "mkdocs-literate-nav",
+    "mkdocstrings[python]",
+    "black",                # Allows mkdocstrings to do formatting...
 ]
+distributed = ["deepspeed", "triton==3.0.0"]
 
 [tool.setuptools.packages.find]
-include = [
-    "whittle",
-    "whittle.*",
-]
+include = ["whittle", "whittle.*"]
 exclude = []
 
 [build-system]
-requires = [
-    "setuptools>=68.2.2",
-    "wheel>=0.41.2",
-]
+requires = ["setuptools>=68.2.2", "wheel>=0.41.2"]
 build-backend = "setuptools.build_meta"
 
 [tool.commitizen]
@@ -86,7 +82,7 @@ version_files = ["pyproject.toml:version", "whittle/__version__.py"]
 changelog_start_rev = "0.1.3"
 
 [tool.ruff]
-target-version = "py39"  # Match lowest supported
+target-version = "py39" # Match lowest supported
 # Exclude a variety of commonly ignored directories.
 exclude = [
     "supernet_configs",
@@ -126,12 +122,12 @@ exclude = [
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
 # McCabe complexity (`C901`) by default.
 select = [
-  "E4",
-  "E7",
-  "E9",
-  "F",
-  "UP",
-  "INP001", # https://docs.astral.sh/ruff/rules/implicit-namespace-package/#implicit-namespace-package-inp001
+    "E4",
+    "E7",
+    "E9",
+    "F",
+    "UP",
+    "INP001", # https://docs.astral.sh/ruff/rules/implicit-namespace-package/#implicit-namespace-package-inp001
 ]
 ignore = []
 


### PR DESCRIPTION
What the PR does: 
- fix triton version to 3.0.0
- move deepspeed and triton to optional dependency group called `distributed`