### PR TITLE
Remove duplicated lora QKV layer

### DIFF
--- a/test/test_lora_attention.py
+++ b/test/test_lora_attention.py
@@ -56,9 +56,7 @@ def init_attention(config):
     attention.attn.linear.weight.data = torch.randn_like(
         attention.attn.linear.weight.data
     )
-    attention.attn.linear.bias.data = torch.randn_like(
-        attention.attn.linear.bias.data
-    )
+    attention.attn.linear.bias.data = torch.randn_like(attention.attn.linear.bias.data)
     attention.proj.linear.bias.data = torch.randn_like(attention.proj.linear.bias.data)
     attention.proj.linear.weight.data = torch.randn_like(
         attention.proj.linear.weight.data

--- a/test/test_lora_attention.py
+++ b/test/test_lora_attention.py
@@ -53,11 +53,11 @@ attention_configs = {
 def init_attention(config):
     attention = CausalSelfAttention(config, 2)
     torch.manual_seed(0)
-    attention.attn.linear.linear.weight.data = torch.randn_like(
-        attention.attn.linear.linear.weight.data
+    attention.attn.linear.weight.data = torch.randn_like(
+        attention.attn.linear.weight.data
     )
-    attention.attn.linear.linear.bias.data = torch.randn_like(
-        attention.attn.linear.linear.bias.data
+    attention.attn.linear.bias.data = torch.randn_like(
+        attention.attn.linear.bias.data
     )
     attention.proj.linear.bias.data = torch.randn_like(attention.proj.linear.bias.data)
     attention.proj.linear.weight.data = torch.randn_like(

--- a/test/test_lora_block.py
+++ b/test/test_lora_block.py
@@ -42,9 +42,7 @@ def test_block():
     block.attn.attn.linear.weight.data = torch.ones_like(
         block.attn.attn.linear.weight.data
     )
-    block.attn.attn.linear.bias.data = torch.ones_like(
-        block.attn.attn.linear.bias.data
-    )
+    block.attn.attn.linear.bias.data = torch.ones_like(block.attn.attn.linear.bias.data)
     block.attn.proj.linear.bias.data = torch.ones_like(block.attn.proj.linear.bias.data)
     block.attn.proj.linear.weight.data = torch.ones_like(
         block.attn.proj.linear.weight.data

--- a/test/test_lora_block.py
+++ b/test/test_lora_block.py
@@ -39,11 +39,11 @@ def test_block():
     block = Block(config, 0)
     input = torch.rand(8, 512, 64)
     mask = build_mask_cache(512)
-    block.attn.attn.linear.linear.weight.data = torch.ones_like(
-        block.attn.attn.linear.linear.weight.data
+    block.attn.attn.linear.weight.data = torch.ones_like(
+        block.attn.attn.linear.weight.data
     )
-    block.attn.attn.linear.linear.bias.data = torch.ones_like(
-        block.attn.attn.linear.linear.bias.data
+    block.attn.attn.linear.bias.data = torch.ones_like(
+        block.attn.attn.linear.bias.data
     )
     block.attn.proj.linear.bias.data = torch.ones_like(block.attn.proj.linear.bias.data)
     block.attn.proj.linear.weight.data = torch.ones_like(

--- a/test/test_lora_gpt.py
+++ b/test/test_lora_gpt.py
@@ -49,11 +49,11 @@ def test_gpt():
     gpt.transformer.ln_f.weight.data = torch.randn_like(gpt.transformer.ln_f.weight.data)
 
     for block in gpt.transformer.h:
-        block.attn.attn.linear.linear.weight.data = torch.randn_like(
-            block.attn.attn.linear.linear.weight.data
+        block.attn.attn.linear.weight.data = torch.randn_like(
+            block.attn.attn.linear.weight.data
         )
-        block.attn.attn.linear.linear.bias.data = torch.randn_like(
-            block.attn.attn.linear.linear.bias.data
+        block.attn.attn.linear.bias.data = torch.randn_like(
+            block.attn.attn.linear.bias.data
         )
         block.attn.proj.linear.bias.data = torch.randn_like(
             block.attn.proj.linear.bias.data
@@ -94,8 +94,8 @@ def test_gpt():
     lit_gpt.transformer.ln_f.weight.data = gpt.transformer.ln_f.weight.data
     for i, block in enumerate(lit_gpt.transformer.h):
         block_orig = gpt.transformer.h[i]
-        block.attn.attn.weight.data = block_orig.attn.attn.linear.linear.weight.data
-        block.attn.attn.bias.data = block_orig.attn.attn.linear.linear.bias.data
+        block.attn.attn.weight.data = block_orig.attn.attn.linear.weight.data
+        block.attn.attn.bias.data = block_orig.attn.attn.linear.bias.data
         block.attn.proj.bias.data = block_orig.attn.proj.linear.bias.data
         block.attn.proj.weight.data = block_orig.attn.proj.linear.weight.data
         block.mlp.fc_1.weight.data = block_orig.mlp.fc_1.linear.weight.data
@@ -140,20 +140,20 @@ def test_gpt():
     for i, block in enumerate(lit_gpt_small.transformer.h):
         block_orig = gpt.transformer.h[i]
         if block_orig.attn.qkv_indices is not None:
-            block.attn.attn.weight.data = block_orig.attn.attn.linear.linear.weight.data[
+            block.attn.attn.weight.data = block_orig.attn.attn.linear.weight.data[
                 block_orig.attn.qkv_indices,
                 : block_orig.attn.attn.sub_network_in_features,
             ]
-            block.attn.attn.bias.data = block_orig.attn.attn.linear.linear.bias.data[
+            block.attn.attn.bias.data = block_orig.attn.attn.linear.bias.data[
                 block_orig.attn.qkv_indices
             ]
             print(torch.tensor(block_orig.attn.qkv_indices).shape)
         else:
-            block.attn.attn.weight.data = block_orig.attn.attn.linear.linear.weight.data[
+            block.attn.attn.weight.data = block_orig.attn.attn.linear.weight.data[
                 : block_orig.attn.attn.sub_network_out_features,
                 : block_orig.attn.attn.sub_network_in_features,
             ]
-            block.attn.attn.bias.data = block_orig.attn.attn.linear.linear.bias.data[
+            block.attn.attn.bias.data = block_orig.attn.attn.linear.bias.data[
                 : block_orig.attn.attn.sub_network_out_features
             ]
         if block_orig.attn.proj_indices is not None:

--- a/whittle/lora/lora_embedding.py
+++ b/whittle/lora/lora_embedding.py
@@ -72,15 +72,16 @@ class LoRAEmbedding(LoRALayer):
 
     def get_lora_AB(self) -> torch.Tensor:
         """Return merged lora_A and lora_B matrices with the same shape as the pretrained weights."""
-        return (
+        ab = (
             self.lora_B[: self.sub_network_embedding_dim, :] @ self.lora_A
         ) * self.scaling
+        return ab.transpose(0, 1)
 
     def merge(self) -> None:
         """Merges the LoRA weights into the full-rank weights (W = W + delta_W)."""
         if self.r > 0 and not self.merged:
             pretrained_dtype = self.embedding.weight.data.dtype
-            lora_data = self.get_lora_AB().transpose(0, 1)
+            lora_data = self.get_lora_AB()
             # if only the pretrained are in quantized form - dequantize, sum with LoRA and quantize the result
             if pretrained_dtype == torch.uint8:
                 import bitsandbytes as bnb

--- a/whittle/lora/lora_linear.py
+++ b/whittle/lora/lora_linear.py
@@ -86,7 +86,7 @@ class LoRALinear(LoRALayer):
     def get_lora_AB(self) -> torch.Tensor:
         """Return merged lora_A and lora_B matrices with the same shape as the pretrained weights."""
         return (
-            self.lora_B[self.sub_network_out_features, :]
+            self.lora_B[: self.sub_network_out_features, :]
             @ self.lora_A[:, : self.sub_network_in_features]
         ) * self.scaling
 
@@ -189,7 +189,7 @@ class LoRALinearQKV(LoRALayer):
     def get_lora_AB(self) -> torch.Tensor:
         """Return merged lora_A and lora_B matrices with the same shape as the pretrained weights."""
         return (
-            self.lora_B[self.sub_network_out_features, :]
+            self.lora_B[: self.sub_network_out_features, :]
             @ self.lora_A[:, : self.sub_network_in_features]
         ) * self.scaling
 
@@ -296,7 +296,7 @@ class LoRALinearProj(LoRALayer):
     def get_lora_AB(self) -> torch.Tensor:
         """Return merged lora_A and lora_B matrices with the same shape as the pretrained weights."""
         return (
-            self.lora_B[self.sub_network_out_features, :]
+            self.lora_B[: self.sub_network_out_features, :]
             @ self.lora_A[:, : self.sub_network_in_features]
         ) * self.scaling
 

--- a/whittle/lora/lora_linear.py
+++ b/whittle/lora/lora_linear.py
@@ -7,7 +7,7 @@ import torch
 import torch.nn as nn
 from litgpt.lora import LoRALayer
 
-from whittle.modules.linear import Linear, LinearProj, LinearQKV
+from whittle.modules.linear import Linear, LinearProj
 
 
 class LoRALinear(LoRALayer):
@@ -130,116 +130,6 @@ class LoRALinear(LoRALayer):
             @ self.lora_A[:, : self.sub_network_in_features].transpose(0, 1)
             @ self.lora_B[: self.sub_network_out_features, :].transpose(0, 1)
         ) * self.scaling
-        return pretrained + lora
-
-
-class LoRALinearQKV(LoRALayer):
-    def __init__(
-        self,
-        in_features: int,
-        out_features: int,
-        r: int = 0,
-        lora_alpha: int = 1,
-        lora_dropout: float = 0.0,
-        **kwargs: Any,
-    ):
-        # Call LoRALayer's constructor with all necessary arguments
-        super().__init__(r=r, lora_alpha=lora_alpha, lora_dropout=lora_dropout)
-
-        # Call LinearQKV's constructor with the required arguments
-        self.linear = LinearQKV(in_features, out_features, **kwargs)
-        self.in_features = in_features
-        self.out_features = out_features
-        self.sub_network_in_features = in_features
-        self.sub_network_out_features = out_features
-        self.use_bias = self.linear.use_bias
-        self.qkv_indices = None
-        self.merged = False
-        # Actual trainable parameters
-        if r > 0:
-            self.lora_A = nn.Parameter(torch.empty((r, in_features)))
-            self.lora_B = nn.Parameter(torch.empty((out_features, r)))
-            self.scaling = self.lora_alpha / self.r
-            self.reset_parameters()
-
-    def set_sub_network(
-        self, sub_network_in_features, sub_network_out_features, qkv_indices=None
-    ):
-        self.sub_network_in_features = sub_network_in_features
-        self.sub_network_out_features = sub_network_out_features
-        self.linear.set_sub_network(
-            sub_network_in_features, sub_network_out_features, qkv_indices
-        )
-        self.qkv_indices = qkv_indices
-
-    def reset_super_network(self):
-        self.sub_network_in_features = self.in_features
-        self.sub_network_out_features = self.out_features
-        self.linear.reset_super_network()
-        self.qkv_indices = None
-
-    def reset_parameters(self) -> None:
-        """Reset all the weights, even including pretrained ones."""
-        if hasattr(self, "lora_A"):
-            # initialize A the same way as the default for nn.Linear and B to zero
-            # Wondering why 'a' is equal to math.sqrt(5)?: https://github.com/pytorch/pytorch/issues/15314
-            nn.init.kaiming_uniform_(self.lora_A, a=math.sqrt(5))
-            nn.init.zeros_(self.lora_B)
-
-    def get_lora_AB(self) -> torch.Tensor:
-        """Return merged lora_A and lora_B matrices with the same shape as the pretrained weights."""
-        return (
-            self.lora_B[: self.sub_network_out_features, :]
-            @ self.lora_A[:, : self.sub_network_in_features]
-        ) * self.scaling
-
-    def merge(self) -> None:
-        """Merges the LoRA weights into the full-rank weights (W = W + delta_W)."""
-        if self.r > 0 and not self.merged:
-            pretrained_dtype = self.linear.weight.data.dtype
-            lora_data = self.get_lora_AB()
-            # if only the pretrained are in quantized form - dequantize, sum with LoRA and quantize the result
-            if pretrained_dtype == torch.uint8:
-                import bitsandbytes as bnb
-
-                weight = self.linear.weight
-                # dequantize the pretrained weights
-                weight_data = bnb.functional.dequantize_4bit(
-                    weight.data, weight.quant_state
-                ).to(lora_data.dtype)
-                # add pretrained and LoRA weights
-                weight_data += lora_data
-                # assign updated weights and quantize by moving to CUDA device
-                self.linear.weight = bnb.nn.Params4bit(
-                    weight_data, requires_grad=False, **weight.__dict__
-                )
-                self.linear.weight.cuda(weight.device)
-            else:
-                # self.linear might be on CPU and lora_data on CUDA
-                # the inplace add will preserve the dtype of linear.weight
-                self.linear.weight.data += lora_data.to(
-                    device=self.linear.weight.data.device
-                )
-            self.merged = True
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        # if weights are merged or rank is less or equal to zero (LoRA is disabled) - it's only a regular nn.Linear forward pass;
-        # otherwise in addition do the forward pass with LoRA weights and add it's output to the output from pretrained weights
-        pretrained = self.linear(x)
-        if self.r == 0 or self.merged:
-            return pretrained
-        if self.qkv_indices is not None:
-            lora = (
-                self.lora_dropout(x)
-                @ self.lora_A[:, : self.sub_network_in_features].transpose(0, 1)
-                @ self.lora_B[self.qkv_indices, :].transpose(0, 1)
-            ) * self.scaling
-        else:
-            lora = (
-                self.lora_dropout(x)
-                @ self.lora_A[:, : self.sub_network_in_features].transpose(0, 1)
-                @ self.lora_B[: self.sub_network_out_features, :].transpose(0, 1)
-            ) * self.scaling
         return pretrained + lora
 
 

--- a/whittle/models/gpt/blocks/causal_self_attention.py
+++ b/whittle/models/gpt/blocks/causal_self_attention.py
@@ -208,6 +208,8 @@ class CausalSelfAttention(nn.Module):
         self.attn.reset_super_network()
         self.proj.reset_super_network()
         self.sub_attention_scaler = self.config.attention_scores_scalar
+        self.qkv_indices = None
+        self.proj_indices = None
 
     def forward(
         self,


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
The linear QKV layer has duplicated logic in `whittle/lora/lora_qkv_linear.py` (module A) and `whittle/lora/lora_linear.py` (module B).

Both modules A and B contain lora_A and lora_B. Module A has an instance of module B inside, but lora_A,B are trained only in module A. Module B can be therefore safely replaced with `LinearQKV` from `whittle/modules/linear.py`

#### Minimal Example / How should this PR be tested?
Passes old tests

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.