### PR TITLE
fix: code in set_sub_network() to set n_head and n_query_groups adjusted

### DIFF
--- a/whittle/models/gpt/model.py
+++ b/whittle/models/gpt/model.py
@@ -198,14 +198,7 @@ class GPT(nn.Module):
         self.sub_network_n_layers = sub_network_n_layers
         self.transformer.wte.set_sub_network(self.sub_network_n_embd)
         self.transformer.ln_f.set_sub_network(self.sub_network_n_embd)
-        if self.config.n_query_groups == 1:
-            self.sub_network_query_groups = 1
-            self.sub_network_num_heads = (
-                sub_network_num_heads
-                if sub_network_num_heads is not None
-                else self.config.n_head
-            )
-        elif self.config.n_head != self.config.n_query_groups:
+        if self.config.n_head % self.config.n_query_groups == 0:
             self.sub_network_num_heads = (
                 sub_network_num_heads
                 if sub_network_num_heads is not None


### PR DESCRIPTION
#### Files affected:
whittle/models/gpt/model.py

#### Reference Issues/PRs
issue #263 

#### What does this implement/fix? Explain your changes.
set_sub_network() does not correctly check compatibility between n_head and n_query_groups
updated this so that litgpt does not throw an assertion error if n_heads != n_query_groups
see [https://github.com/Lightning-AI/litgpt/blob/main/litgpt/config.py](url) (class config -> __post_init__() -> # compute the number of query groups) 

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.