### PR TITLE
fix: off-by-one error in bin sampling

### DIFF
--- a/test/test_search.py
+++ b/test/test_search.py
@@ -89,12 +89,14 @@ def test_param_bins(bin_t, bin_s, bin_n):
 
     # fill up to bin_n - 1 bins
     for j in range(bin_s):
-        for i in range(bin_n - bin_t - 1):
+        for i in range(bin_n - bin_t):
+            if i == 1:
+                continue
             assert bins.put_in_bin({"a": 1 + i * bin_width})
 
         # fill the last one unless it'd be filled fully (leave 1 not full)
         if j < bin_s - 1:
-            assert bins.put_in_bin({"a": 1 + (bin_n - bin_t - 1) * bin_width})
+            assert bins.put_in_bin({"a": 1 + bin_width})
 
     assert bins.current_bin_length == bin_s
 
@@ -106,7 +108,7 @@ def test_param_bins(bin_t, bin_s, bin_n):
     assert sum([b == bin_s for b in bins.bins]) == bin_n - bin_t - 1
 
     # last bin is filled fully -> this should be true
-    assert bins.put_in_bin({"a": 2 + bin_width * (bin_n - bin_t - 1)})
+    assert bins.put_in_bin({"a": 2 + bin_width})
     # all filled
     assert sum([b == bin_s for b in bins.bins]) == bin_n - bin_t
 

--- a/test/test_search.py
+++ b/test/test_search.py
@@ -102,7 +102,15 @@ def test_param_bins(bin_t, bin_s, bin_n):
     assert not bins.put_in_bin({"a": 3})
     assert bins.current_bin_length == bin_s
 
+    # all but one filled (- tolerance)
+    assert sum([b == bin_s for b in bins.bins]) == bin_n - bin_t - 1
+
     # last bin is filled fully -> this should be true
     assert bins.put_in_bin({"a": 2 + bin_width * (bin_n - bin_t - 1)})
+    # all filled
+    assert sum([b == bin_s for b in bins.bins]) == bin_n - bin_t
+
     assert bins.put_in_bin({"a": 3})
     assert bins.current_bin_length == bin_s + 1
+    # all almost filled - 1 filled (- tolerance)
+    assert sum([b == bin_s for b in bins.bins]) == bin_n - bin_t - 1

--- a/whittle/eval/whittle_llms.py
+++ b/whittle/eval/whittle_llms.py
@@ -14,6 +14,7 @@ from lm_eval import utils
 from lm_eval.api.instance import Instance
 from lm_eval.api.model import TemplateLM
 from lm_eval.api.registry import register_model
+from lm_eval.evaluator_utils import eval_logger
 from lm_eval.models.utils import (
     Collator,
     clear_torch_cache,
@@ -28,8 +29,6 @@ from transformers.models.auto.modeling_auto import (
 )
 
 from whittle.models.gpt import GPT
-
-eval_logger = utils.eval_logger
 
 
 def _get_accelerate_args(

--- a/whittle/sampling/param_bins.py
+++ b/whittle/sampling/param_bins.py
@@ -62,6 +62,9 @@ class ParamBins:
         placed = False
         at_max_length = 0
         for i, value in enumerate(self.values):
+            if i == 0:
+                continue
+
             # get the first bin
             if not found and params <= value:
                 found = True


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
There was an off-by-one error - the last bin was counted twice by mistake due to python indexing:

```
for i, value in enumerate(self.values):
    if self.bins[i - 1] == self.current_bin_length:
         at_max_length += 1
```

The tests did not catch this as they are filling bins from index 0 to -1, and so the last one is always empty.

#### Minimal Example / How should this PR be tested?
I added a `continue` in case `i == 0`.
I added a test that checks whether all of them are the same size. Also, the last unfilled bin is now bins[1] instead of bins[-1].

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.