### PR TITLE
refactor(flops.py): Use Lightning instead of Deepspeed to measure flops

### DIFF
--- a/examples/profile/profile_flops.py
+++ b/examples/profile/profile_flops.py
@@ -35,8 +35,6 @@ if __name__ == "__main__":
     config.n_layer = 4
     model = GPT(config)
     print(f"Full model {compute_flops(model=model, metric='flops')} flops")
-    print(f"Full model {compute_flops(model=model, metric='macs')} macs")
     config = update_config(config, 64, 64 * 4, 4, 2, 4)
     model = GPT(config)
     print(f"Mini model {compute_flops(model=model, metric='flops')} flops")
-    print(f"Mini model {compute_flops(model=model, metric='macs')} macs")

--- a/examples/profile/profile_flops.py
+++ b/examples/profile/profile_flops.py
@@ -34,7 +34,7 @@ if __name__ == "__main__":
     config.intermediate_size = 128 * 4
     config.n_layer = 4
     model = GPT(config)
-    print(f"Full model {compute_flops(model=model, metric='flops')} flops")
+    print(f"Full model {compute_flops(model=model)} flops")
     config = update_config(config, 64, 64 * 4, 4, 2, 4)
     model = GPT(config)
-    print(f"Mini model {compute_flops(model=model, metric='flops')} flops")
+    print(f"Mini model {compute_flops(model=model)} flops")

--- a/whittle/metrics/flops.py
+++ b/whittle/metrics/flops.py
@@ -13,7 +13,7 @@ def compute_flops(
     batch_size: int = 1,
     sequence_length: int = 512,
     metric: Literal["flops"] = "flops",
-    device: str = "cuda",
+    device: str = "cpu",
     previous_device: str | None = None,
     verbose: bool = False,
 ) -> float:

--- a/whittle/metrics/flops.py
+++ b/whittle/metrics/flops.py
@@ -34,7 +34,7 @@ def compute_flops(
         verbose: If True, prints debug information about profiling.
 
     Returns:
-        A dictionary containing FLOPs, batch size, sequence length, and device used.
+        The estimated number of floating-point operations (FLOPs) for the model's forward pass.
     """
     if metric != "flops":
         raise ValueError("Only 'flops' metric is supported.")

--- a/whittle/metrics/flops.py
+++ b/whittle/metrics/flops.py
@@ -1,17 +1,9 @@
 from __future__ import annotations
 
-import os
 from typing import Literal
 
-try:
-    import deepspeed
-except ImportError:
-    raise ImportError(
-        "DeepSpeed not installed. Please install whittle with the "
-        "`distributed` dependency group: `pip install whittle[distributed]"
-    )
-
 import torch
+from lightning.fabric.utilities.throughput import measure_flops
 
 from whittle.models.gpt import GPT
 
@@ -20,51 +12,70 @@ def compute_flops(
     model: GPT,
     batch_size: int = 1,
     sequence_length: int = 512,
-    metric: Literal["flops", "macs"] = "flops",
+    metric: Literal["flops"] = "flops",
+    device: str = "cuda",
     previous_device: str | None = None,
+    verbose: bool = False,
 ) -> float:
     """
-    Estimates the number of floating-point operations (FLOPs) or multiply-accumulate operations (MACs) for a GPT model.
+    Estimates the number of floating-point operations (FLOPs) for a GPT model using PyTorch Lightning.
 
-    This function uses DeepSpeed's FlopsProfiler to estimate the FLOPs or MACs of the model's forward pass.
+    This function uses Lightning's measure_flops utility to estimate the FLOPs of the model's forward pass
+    on a specified device. The model will be temporarily moved to the given device if not already there.
+    After profiling, it will be moved back to the previous device if specified.
 
     Args:
         model: The GPT model to profile.
-        batch_size: The batch size for the input tensor. Defaults to 1.
-        sequence_length: The sequence length for the input tensor. Defaults to 512.
-        metric: The metric to return. Either "flops" for floating-point operations or "macs" for multiply-accumulate operations. Defaults to "flops".
-        previous_device: The device to cast to after profiling. If None, the device is not changed. Defaults to None.
+        batch_size: The batch size for the input tensor.
+        sequence_length: The sequence length for the input tensor.
+        device: The device on which to run the FLOPs calculation ("cpu", "cuda", etc.).
+        previous_device: Optional device to move the model back to after profiling.
+        metric: Currently only "flops" is supported.
+        verbose: If True, prints debug information about profiling.
 
     Returns:
-        The estimated number of floating-point operations (FLOPs) or multiply-accumulate operations (MACs) for the model's forward pass, depending on the specified metric.
+        A dictionary containing FLOPs, batch size, sequence length, and device used.
     """
+    if metric != "flops":
+        raise ValueError("Only 'flops' metric is supported.")
 
-    from deepspeed.accelerator.cpu_accelerator import CPU_Accelerator
-    from deepspeed.profiling.flops_profiler import get_model_profile
+    if device == "cuda" and not torch.cuda.is_available():
+        raise RuntimeError("CUDA requested but is not available.")
+
+    original_device = next(model.parameters()).device
+    if original_device.type == "meta":
+        raise RuntimeError(
+            "Model is on 'meta' device; cannot run FLOPs profiling without real weights."
+        )
+
+    if verbose:
+        print(f"[FLOPs] Profiling on device: {device}")
+        print(
+            f"[FLOPs] Model: {model.__class__.__name__}, Batch size: {batch_size}, Seq length: {sequence_length}"
+        )
+        print(f"[FLOPs] Original device: {original_device}, Target device: {device}")
+
+    if str(original_device) != device:
+        model.to(device)
 
     input_tensor = torch.randint(
-        0, model.config.padded_vocab_size, (batch_size, sequence_length)
+        0, model.config.padded_vocab_size, (batch_size, sequence_length), device=device
     )
 
-    model.eval()
-    model.to("cpu")
+    def forward_fn():
+        return model(input_tensor)
 
-    os.environ["DS_ACCELERATOR"] = "CPU"
-    deepspeed.accelerator.set_accelerator(CPU_Accelerator())
-
-    flops, macs, _ = get_model_profile(
-        model=model,
-        args=(input_tensor,),
-        print_profile=False,
-        detailed=False,
-        warm_up=1,
-        as_string=False,
-    )
+    try:
+        flops = measure_flops(model, forward_fn)
+    except Exception as e:
+        raise RuntimeError(f"Failed to compute FLOPs: {e}")
 
     if previous_device is not None:
         model.to(previous_device)
+    elif str(original_device) != device:
+        model.to(original_device)
 
-    if metric == "flops":
-        return flops
-    else:
-        return macs
+    if verbose:
+        print(f"[FLOPs] Estimated: {flops:.2e}")
+
+    return flops

--- a/whittle/metrics/flops.py
+++ b/whittle/metrics/flops.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Literal
-
 import torch
 from lightning.fabric.utilities.throughput import measure_flops
 
@@ -12,7 +10,6 @@ def compute_flops(
     model: GPT,
     batch_size: int = 1,
     sequence_length: int = 512,
-    metric: Literal["flops"] = "flops",
     device: str = "cpu",
     previous_device: str | None = None,
     verbose: bool = False,
@@ -30,15 +27,11 @@ def compute_flops(
         sequence_length: The sequence length for the input tensor.
         device: The device on which to run the FLOPs calculation ("cpu", "cuda", etc.).
         previous_device: Optional device to move the model back to after profiling.
-        metric: Currently only "flops" is supported.
         verbose: If True, prints debug information about profiling.
 
     Returns:
         The estimated number of floating-point operations (FLOPs) for the model's forward pass.
     """
-    if metric != "flops":
-        raise ValueError("Only 'flops' metric is supported.")
-
     if device == "cuda" and not torch.cuda.is_available():
         raise RuntimeError("CUDA requested but is not available.")
 


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes: https://github.com/whittle-org/whittle/issues/276

#### What does this implement/fix? Explain your changes.

This PR refines the compute_flops function responsible for estimating floating-point operations (FLOPs) for a GPT model. The following key improvements have been made:

- Switch from DeepSpeed to Lightning: The function now uses the `measure_flops` utility from PyTorch Lightning instead of the DeepSpeed implementation, providing a more lightweight and integrated method for profiling FLOPs.

- Device Flexibility: The function now accepts a device argument, allowing users to specify the device on which to perform the FLOPs calculation (e.g., 'cpu', 'cuda').

- Verbosity: Introduced an optional verbose flag for debug output.

 