### PR TITLE
fix: fix crash when checkpointing

### DIFF
--- a/test/test_pretrain_super_network.py
+++ b/test/test_pretrain_super_network.py
@@ -21,7 +21,7 @@ from whittle import pretrain_super_network
 MODEL_NAME = "EleutherAI/pythia-14m"
 
 
-@mock.patch("litgpt.pretrain.save_hyperparameters")
+@mock.patch("whittle.pretrain_super_network.save_hyperparameters")
 @pytest.mark.parametrize("strategy", ["standard", "random", "sandwich"])
 def test_training_strategies(
     save_hyperparameters_mock, strategy, tmp_path, accelerator_device
@@ -61,7 +61,7 @@ def test_training_strategies(
 # If we were to use `save_hyperparameters()`, we would have to patch `sys.argv` or otherwise
 # the CLI would capture pytest args, but unfortunately patching would mess with subprocess
 # launching, so we need to mock `save_hyperparameters()`
-@mock.patch("litgpt.pretrain.save_hyperparameters")
+@mock.patch("whittle.pretrain_super_network.save_hyperparameters")
 def test_pretrain(save_hyperparameters_mock, tmp_path, accelerator_device):
     model_config = Config(
         block_size=2, n_layer=2, n_embd=8, n_head=4, padded_vocab_size=8
@@ -122,7 +122,7 @@ def test_pretrain(save_hyperparameters_mock, tmp_path, accelerator_device):
 @mock.patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": "0,1"})
 @mock.patch("litgpt.pretrain.L.Fabric.load_raw")
 # See comment in `test_pretrain` why we need to mock `save_hyperparameters()`
-@mock.patch("litgpt.pretrain.save_hyperparameters")
+@mock.patch("whittle.pretrain_super_network.save_hyperparameters")
 def test_initial_checkpoint_dir(_, load_mock, tmp_path):
     model_config = Config(
         block_size=2, n_layer=2, n_embd=8, n_head=4, padded_vocab_size=8

--- a/whittle/pretrain_super_network.py
+++ b/whittle/pretrain_super_network.py
@@ -76,7 +76,7 @@ def setup(
     model_name: str,
     model_config: Config | None = None,
     out_dir: Path = Path("../examples/gpt/out/pretrain"),
-    precision: Literal["bf16-true", "bf16-mixed", "32-true", None] = "None",
+    precision: Literal["bf16-true", "bf16-mixed", "32-true", None] = None,
     initial_checkpoint_dir: Path | None = None,
     resume: bool | Literal["auto"] | Path = False,
     data: DataModule | None = None,

--- a/whittle/pretrain_super_network.py
+++ b/whittle/pretrain_super_network.py
@@ -20,7 +20,6 @@ from litgpt.pretrain import (
     get_dataloaders,
     get_lr,
     initialize_weights,
-    save_checkpoint,
     validate,
     validate_args,
 )


### PR DESCRIPTION
#### Reference Issues/PRs
This PR resolves #295 

#### What does this implement/fix? Explain your changes.
`litgpt.pretrain.save_checkpoint()` uses `litgpt.pretrain.setup(...)` as the reference function to save the hyperparameters which are passed into it. However, there is a mis-match in the function parameters between `litgpt.pretrain.setup(...)` and `whittle.pretrain_super_networks.setup(...)`, with the latter having more parameters such as `accelerator` and `training_strategy`. When these arguments are explicitly passed into the function via the command line (instead of consuming the default values), the script crashes inside `litgpt.pretrain.save_checkpoint()`.

As a workaround, I re-implemented `save_checkpoint()` in Whittle.

#### Minimal Example / How should this PR be tested?
The command provided in #295 will now work smoothly.

#### Any other comments?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.