### PR TITLE
fix(evaluation): fix bug in subnetwork evaluation

### DIFF
--- a/whittle/evaluate_network.py
+++ b/whittle/evaluate_network.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import torch
 from litgpt import Config
 
 from whittle.eval.utils import convert_and_evaluate
@@ -66,6 +67,9 @@ def setup(
             model, batch_size=latency_batch_size, previous_device=device
         )
     metrics_path.write_text(json.dumps(metrics, indent=2))
+
+    if device is None:
+        device = "cuda" if torch.cuda.is_available() else "cpu"
 
     # downstream task evaluation
     model.to(device)


### PR DESCRIPTION
#### Reference Issues/PRs
This PR addresses #299 

#### What does this implement/fix? Explain your changes.
The network evaluation code initially assigns `None` as the default device for the model. However, later, the device is inferred using `torch.cuda.is_available()`. This causes a mismatch in the devices of the weight and data tensors, causing a crash.

This fix infers the correct device in the beginning itself.

#### Minimal Example / How should this PR be tested?
The following command will now work (provided `sub_networks/sub_network_0` has a valid checkpoint in it):
```bash
python whittle/evaluate_network.py sub_networks/sub_network_0/ \
    --out_dir evaluation/ \
    --task arc_easy
```
---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.