### PR TITLE
fix: fix broken HF access token for LlaMaMini

### DIFF
--- a/whittle/full_finetune.py
+++ b/whittle/full_finetune.py
@@ -102,7 +102,13 @@ def setup(
         model_name=checkpoint_dir, access_token=access_token
     )
     pprint(locals())
-    data = LLaMaMini() if data is None else data
+
+    def init_LLaMaMini() -> LLaMaMini:
+        return (
+            LLaMaMini() if access_token is None else LLaMaMini(access_token=access_token)
+        )
+
+    data = init_LLaMaMini() if data is None else data
     num_devices = parse_devices(devices)
     out_dir = init_out_dir(out_dir)
 

--- a/whittle/lora.py
+++ b/whittle/lora.py
@@ -214,7 +214,9 @@ def setup(
     if data_str == "alpaca":
         data = Alpaca()
     elif data_str == "llamamini":
-        data = LLaMaMini()
+        data = (
+            LLaMaMini() if access_token is None else LLaMaMini(access_token=access_token)
+        )
     else:
         data = None
     devices = parse_devices(devices)


### PR DESCRIPTION
#### Reference Issues/PRs
This PR resolves #301 

#### What does this implement/fix? Explain your changes.
See #301 

#### Minimal Example / How should this PR be tested?

1. Remove the HF_TOKEN from the environment variables.
2. Run full fine-tuning (assumes that there is a valid checkpoint in `sub_networks/sub_network_0`):
```bash
python /whittle/full_finetune.py sub_networks/sub_network_0 \
     --train.max_seq_length 512 \
     --access_token <your_access_token> 
```
3. The code will run without errors
---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.