### PR TITLE
fix(lora): fix crash in LoRA finetuning of supernet

### DIFF
--- a/whittle/lora.py
+++ b/whittle/lora.py
@@ -159,7 +159,6 @@ def setup(
         max_seq_length=None,
     ),
     train_strategy: str = "sandwich",
-    search_space_type: str = "hw_gpt_bench",
     eval: EvalArgs = EvalArgs(interval=10, max_new_tokens=100, max_iters=100),
     optimizer: str | dict = "AdamW",
     logger_name: Literal["wandb", "tensorboard", "csv"] = "wandb",
@@ -246,11 +245,11 @@ def setup(
     n_trials = sampler.n_trials
     # Create a timestamp with nanosecond precision
     time_string = now.strftime("%Y%m%d_%H%M%S")
-    search_space = search_spaces[search_space_type](config)
+    search_space = search_spaces["lora"](config)
     out_dir = Path(
-        f"{config.name}-{train_strategy}-{search_space_type}-{sampling_strategy}-{data_str}/finetune/lora/"
+        f"{config.name}-{train_strategy}-lora-{sampling_strategy}-{data_str}/finetune/lora/"
     )
-    id = f"{train_strategy}-{search_space_type}-{sampling_strategy}-{time_string}-{data_str}-lora"
+    id = f"{train_strategy}-lora-{sampling_strategy}-{time_string}-{data_str}-lora"
     precision = precision or get_default_supported_precision(training=True)
     logger = choose_logger(
         logger_name,
@@ -261,7 +260,7 @@ def setup(
         resume=bool(resume),
         config=dict(
             train_strategy=train_strategy,
-            search_space_type=search_space_type,
+            search_space_type="lora",
             sampling_strategy=sampling_strategy,
             data=data_str,
             lora_r=lora_r,

--- a/whittle/lora.py
+++ b/whittle/lora.py
@@ -192,7 +192,6 @@ def setup(
         data: Data-related arguments. If not provided, the default is ``litgpt.data.Alpaca``.
         train: Training-related arguments. See ``litgpt.args.TrainArgs`` for details.
         train_strategy: The training strategy to use. Possible choices: "sandwich", "standard".
-        search_space_type: The search space to use. Possible choices: "small", "medium", "hw_gpt_bench", "llama_joint".
         eval: Evaluation-related arguments. See ``litgpt.args.EvalArgs`` for details.
         optimizer: An optimizer name (such as "AdamW") or config.
         logger_name: The name of the logger to send metrics to.

--- a/whittle/search/search_spaces.py
+++ b/whittle/search/search_spaces.py
@@ -14,6 +14,25 @@ class SimpleSearchSpace:
         return config
 
 
+class LoraSearchSpace(SimpleSearchSpace):
+    def __init__(self, gpt_model_specification):
+        self.config_space = {
+            "n_embd": lograndint(32, gpt_model_specification.n_embd),
+            "n_layers": randint(1, gpt_model_specification.n_layer),
+            "heads": randint(1, gpt_model_specification.n_head),
+            "intermediate_size": randint(1, gpt_model_specification.intermediate_size),
+        }
+
+    @staticmethod
+    def cast(config):
+        return {
+            "sub_network_n_embd": config["n_embd"],
+            "sub_network_intermediate_size": config["intermediate_size"],
+            "sub_network_num_heads": config["heads"],
+            "sub_network_n_layers": config["n_layers"],
+        }
+
+
 class SmallSearchSpace(SimpleSearchSpace):
     def __init__(self, gpt_model_specification):
         self.config_space = {
@@ -118,6 +137,7 @@ class LlamaJoint(SimpleSearchSpace):
 
 
 search_spaces = {
+    "lora": LoraSearchSpace,
     "small": SmallSearchSpace,
     "medium": MediumSearchSpace,
     "hw_gpt_bench": HWGPTBench,


### PR DESCRIPTION
#### Reference Issues/PRs
This PR resolves #303 

#### What does this implement/fix? Explain your changes.
The LoRA finetuning of the supernet was crashing because `LoRAQKVLinear.set_sub_network(...)` was being called with a `list[int]` for the parameter `sub_network_n_head` instead of an `int`.

#265 introduced a few new search spaces in  `whittle/search/search_spaces`, including:
1. `SmallSearchSpace`
2. `MediumSearchSpace`
3. `HWGPTBench`
4. `LlamaJoint`

These are imported only in `lora.py`, and can be chosen via the `search_space_type` parameter of `setup`, but all of them crash the run when consumed in the script. `HWGPTBench` is the default.

The reason is that the `cast(config)` method of these search spaces, which is invoked inside the `RandomSampler`, sets `"sub_network_num_heads"` as a list of ints instead of a single int.

To address the issue, a new search space class called `LoraSearchSpace` is introduced, which properly casts the configuration.

#### Minimal Example / How should this PR be tested?
See script provided in #303 

**Additional context**
It is not clear to me what the intention of the new `XYZSearchSpace` classes mentioned above are, so I left them unchanged. They're not consumed anywhere, though, and if consumed, they would crash the run. Looking at them, it seems as if the desired result is for the sampling of subnetworks to be very granular, e.g., different number of heads for different layers. However, this is not the behaviour of the subnetwork sampling during pretraining with `whittle/pretrain`.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.