### PR TITLE
feat(litgpt_conversion): add CLI for conversion script

### DIFF
--- a/whittle/convert_to_litgpt.py
+++ b/whittle/convert_to_litgpt.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import shutil
 from pathlib import Path
 
@@ -50,6 +51,9 @@ def setup(
 
     if out_dir is None:
         out_dir = sub_network_dir
+
+    if not os.path.exists(out_dir):
+        out_dir.mkdir(parents=True, exist_ok=True)
 
     ckp = lazy_load(sub_network_dir / "lit_model.pth")
 
@@ -114,3 +118,11 @@ def setup(
         )
         torch.save(save_data, out_dir / "lit_model.pth")
         save_config(sub_network.config, out_dir)
+
+    print(f"Converted sub-network saved to {out_dir}")
+
+
+if __name__ == "__main__":
+    from jsonargparse import CLI
+
+    CLI(setup)


### PR DESCRIPTION
#### Reference Issues/PRs
This PR resolves #307 

#### What does this implement/fix? Explain your changes.
Adds CLI to the `setup` function defined in `convert_to_litgpt.py`. Also handles the case if the target directory does not exist.

#### Minimal Example / How should this PR be tested?
Assuming there is a sub_network in `sub_networks/sub_network_0/`:
```bash
python whittle/convert_to_litgpt.py sub_networks/sub_network_0/ --out_dir litgpt_checkpoint
```
---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.