### PR TITLE
fix(measure_flops): fix bug in measuring flops

### DIFF
--- a/whittle/metrics/flops.py
+++ b/whittle/metrics/flops.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 
 import torch
 from lightning.fabric.utilities.throughput import measure_flops
+from lightning.fabric.wrappers import _FabricModule
 
 from whittle.models.gpt import GPT
 
@@ -60,7 +61,10 @@ def compute_flops(
     )
 
     def forward_fn() -> torch.Tensor:
-        return model(input_tensor)
+        if isinstance(model, _FabricModule):
+            return model.module(input_tensor)
+        else:
+            return model(input_tensor)
 
     model_loss: Callable[[torch.Tensor], torch.Tensor] | None = None
     if loss_fn is not None:


### PR DESCRIPTION
#### Reference Issues/PRs
This PR resolves #297 

#### What does this implement/fix? Explain your changes.
The code would crash with some precisions such as `bf16-mixed` and `16-mixed`. The problem was that `lightning.fabric.utilities.throughput.measure_flops`, which is consumed in `whittle.metrics.flops.compute_flops`, expects a PyTorch model but a PyTorch model wrapped in PyTorch Lightning Fabric was passed into it.

#### Minimal Example / How should this PR be tested?
The following script crashes without the fix but now it works
```
python whittle/pretrain_super_network.py EleutherAI/pythia-14m \
    --data TinyStories \
    --data.data_path ./data \
    --tokenizer_dir ~/checkpoints/EleutherAI/pythia-14m/ \
    --out_dir pretrained_super_net \
    --train.save_interval 5 \
    --train.max_tokens 1000000000
```
---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.