### PR TITLE
fix(pretraining): disable torch.compile() supernet

### DIFF
--- a/whittle/pretrain_super_network.py
+++ b/whittle/pretrain_super_network.py
@@ -468,7 +468,9 @@ def main(
     fabric.print(f"Time to instantiate model: {time.perf_counter() - t0:.02f} seconds.")
     fabric.print(f"Total parameters: {num_parameters(model):,}")
 
-    model = torch.compile(model)
+    if training_strategy == "standard":
+        model = torch.compile(model)
+
     model = fabric.setup(model)
 
     extra_kwargs = {"fused": fabric.device.type == "cuda"}


### PR DESCRIPTION
#### Reference Issues/PRs
This PR resolves #312 

#### What does this implement/fix? Explain your changes.
`torch.compile` slows down pretraining when the strategies consumed the `supernet.set_sub_network()` API. This PR compiles the supernet only if the pretraining strategy used is `standard` (which is the only strategy which does not use the API)

#### Minimal Example / How should this PR be tested?
Apply this commit to the `profle_supernet` branch mentioned in #312 and follow the instructions in it to reproduce the issue. The bottleneck will disappear.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.