### PR TITLE
fix(lora_finetuning): fix bug when using stratified_random strategy

### DIFF
--- a/whittle/lora.py
+++ b/whittle/lora.py
@@ -360,6 +360,10 @@ def main(
             fabric.print("Initializing params grid....")
             strategy.sampler.initialize_grid(model)
             fabric.print("Grid Size", len(strategy.sampler.grid))
+        elif "stratified_random" in sampling_strategy:
+            fabric.print("Initializing param bins...")
+            strategy.sampler.initialize_param_bins(model)  # type: ignore
+
     model.name_or_path = checkpoint_dir
     mark_only_lora_as_trainable(model)
 

--- a/whittle/sampling/random_sampler.py
+++ b/whittle/sampling/random_sampler.py
@@ -6,6 +6,8 @@ from typing import Any
 import numpy as np
 from syne_tune.config_space import Categorical, Domain
 
+from whittle.metrics.parameters import compute_parameters
+from whittle.models.gpt import GPT
 from whittle.search.search_spaces import SimpleSearchSpace
 
 
@@ -140,3 +142,23 @@ class RandomSampler(BaseSampler):
                     config[k] = (v.lower + v.upper) // 2
 
         return self.search_space.cast(config) if self.cast_search_space else config
+
+    def get_parameters(self, model: GPT, config) -> float:
+        """
+        Counts the number of parameters in the model for the given configuration
+
+        Args:
+            model       : GPT model
+            config      : Configuration of sub-network of the model
+
+        Returns:
+            The number of parameters of the activated sub-network
+        """
+        if self.cast_search_space:
+            model.set_sub_network(**config)
+        else:
+            model.select_sub_network(config)
+
+        params = compute_parameters(model)
+        model.reset_super_network()
+        return params

--- a/whittle/sampling/random_sampler.py
+++ b/whittle/sampling/random_sampler.py
@@ -143,13 +143,13 @@ class RandomSampler(BaseSampler):
 
         return self.search_space.cast(config) if self.cast_search_space else config
 
-    def get_parameters(self, model: GPT, config) -> float:
+    def get_parameters(self, model: GPT, config: dict[str, Any]) -> float:
         """
         Counts the number of parameters in the model for the given configuration
 
         Args:
-            model       : GPT model
-            config      : Configuration of sub-network of the model
+            model: GPT model
+            config: Configuration of sub-network of the model
 
         Returns:
             The number of parameters of the activated sub-network

--- a/whittle/sampling/samplers.py
+++ b/whittle/sampling/samplers.py
@@ -17,8 +17,7 @@ def get_sampler(sampler_type, search_space, seed, num_configs, n_trials, **kwarg
         return StratifiedRandomSampler(
             search_space=search_space,
             seed=seed,
-            n_trials=n_trials,
-            num_configs=num_configs,
+            max_tries=n_trials,
             **kwargs,
         )
     elif sampler_type == Samplers.GRID_PARAMS:


### PR DESCRIPTION
#### Reference Issues/PRs
This PR resolves #305 

#### What does this implement/fix? Explain your changes.
The `StratifiedRandomSampler` requires `params_estimator`, which further requires the initialized GPT model. This isn't available at the time of instantiating the sampler. This fix follows the same paradigm as `FixedParamGridSampler` to handle this.

The parameters being passed into `StratifiedRandomSampler` in `def get_sampler(...)` were also incorrect. Fixed that.
#### Minimal Example / How should this PR be tested?

```
python whittle/lora.py sub_networks/sub_network_0/  --out_dir evaluation --train.max_seq_length 512 --sampler.sampling_strategy stratified_random
```

#### Any other comments?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.