### PR TITLE
fix: fix regression

### DIFF
--- a/test/test_attention.py
+++ b/test/test_attention.py
@@ -192,6 +192,15 @@ QKV_INDICES_TEST_CONFIGS = {
             ]  # values
         ),
     ],
+    "gqa_to_gqa_2": [
+        (64, 16, 4, 2),  # supernet  n_embd, n_head, query_groups, head_size
+        (64, 6, 3, 1),  # subnet    n_embd, n_head, query_groups, head_size
+        (
+            [0, 2, 8, 10, 16, 18]  # queries
+            + [32, 34, 36]  # keys
+            + [40, 42, 44]  # values
+        ),
+    ],
     "gqa_to_gqa_slice_head": [
         (64, 12, 3, 2),  # supernet  n_embd, n_head, query_groups, head_size
         (64, 8, 2, 1),  # subnet    n_embd, n_head, query_groups, head_size

--- a/whittle/models/gpt/blocks/causal_self_attention.py
+++ b/whittle/models/gpt/blocks/causal_self_attention.py
@@ -125,7 +125,7 @@ class CausalSelfAttention(nn.Module):
         sub_head_size = self.sub_network_head_size
         sub_q_groups = self.sub_network_query_groups
         sub_q_per_kv = self.sub_network_q_per_kv
-        sub_heads_per_group = sub_n_head // sub_q_groups
+        heads_per_group = n_head // n_query_groups
 
         # Get the attention type of the supernet:
         # multi-head, multi query, or grouped query attention
@@ -173,7 +173,7 @@ class CausalSelfAttention(nn.Module):
         else:  # grouped query attention
             for g in range(sub_q_groups):
                 for h in range(sub_q_per_kv):
-                    q_head_index = g * sub_heads_per_group + h
+                    q_head_index = g * heads_per_group + h
                     q_start = q_block_start + q_head_index * head_size
                     q_parts.append(torch.arange(q_start, q_start + sub_head_size))
 
@@ -272,7 +272,7 @@ class CausalSelfAttention(nn.Module):
         self.qkv_indices = self.get_qkv_indices()
         self.proj_indices = self.qkv_indices[
             : torch.searchsorted(
-                self.qkv_indices, sub_network_n_head * self.config.head_size, right=False
+                self.qkv_indices, self.config.n_head * self.config.head_size, right=False
             )
         ]
 


### PR DESCRIPTION
#### Reference Issues/PRs
This PR fixes a regression that was introduced in #324 

#### What does this implement/fix? Explain your changes.
There are two mistakes in #324.

First, the simplified calculation of the `proj_indices` incorrectly uses the number of heads in the _subnetwork_ to compute the indices, rather than the number of heads in the _supernet_.

Second, this same mistake is repeated in the computation of `qkv_indices` for the case of _grouped query attention_.

#### Minimal Example / How should this PR be tested?
A new test case has been added in `tests/test_attention.py` to test for this failure case specifically.

#### Any other comments?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.