### PR TITLE
ci: update version of lm-eval

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "torch>=2.5",
     "transformers>=4.51.3,<4.54",
     "litgpt[extra]==0.5.10",
+    "lm-eval<0.4.9.1",
     "syne-tune[moo]==0.13.0",
     "torchvision>=0.18",
     "boto3==1.34.147",


### PR DESCRIPTION
#### Reference Issues/PRs
This PR resolves #351

#### What does this implement/fix? Explain your changes.
The regression was introduced in `lm-eval v0.4.9.1`. This PR forces the project to use a lesser version. See [this](https://github.com/Lightning-AI/litgpt/pull/2102) PR which addresses it in the `litgpt` repo. 


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.