### PR TITLE
fix: fix gemma-3 models

### DIFF
--- a/test/test_model.py
+++ b/test/test_model.py
@@ -232,6 +232,25 @@ def test_gemma_2():
     assert torch.allclose(whittle_out, lit_out, atol=1e-3)
 
 
+def test_gemma_3():
+    config_gemma = Config.from_name(
+        "gemma-3-1b-it",
+        block_size=6,
+        sliding_window_size=3,
+        n_layer=2,
+        n_embd=32,
+        intermediate_size=86,
+    )
+    config_gemma.fix_head_size = True
+    lit_model = LitGPT(config_gemma)
+    whittle_model = GPT(config_gemma)
+    copy_weights(lit_model, whittle_model)
+    x = torch.tensor([[9856, 23, 491, 1536, 304, 1234]], dtype=torch.int32)
+    whittle_out = whittle_model(x)
+    lit_out = lit_model(x)
+    assert torch.allclose(whittle_out, lit_out, atol=1e-3)
+
+
 def test_qwen_3():
     T = 5
     config_qwen = Config.from_name(

--- a/whittle/models/gpt/model.py
+++ b/whittle/models/gpt/model.py
@@ -677,7 +677,18 @@ class GPT(nn.Module):
         cos, sin, mask, input_pos_maxp1_block = self.process_rope_cache(
             cos, sin, input_pos, input_pos_maxp1, T
         )
-        x = block(x, cos, sin, mask, input_pos, input_pos_maxp1_block)
+
+        if self.config.rope_indices is not None:
+            x = block(
+                x,
+                cos[..., self.config.rope_indices[j]],
+                sin[..., self.config.rope_indices[j]],
+                mask,
+                input_pos,
+                input_pos_maxp1,
+            )
+        else:
+            x = block(x, cos, sin, mask, input_pos, input_pos_maxp1_block)
 
         return x
 


### PR DESCRIPTION
#### Reference Issues/PRs
This PR resolves #361 

#### What does this implement/fix? Explain your changes.
Gemma models consume `config.rope_indices`. This was not handled before.

#### Minimal Example / How should this PR be tested?
Run the newly added test:
`pytest test/test_model.py  -k test_gemma_3`

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.