### PR TITLE
feat: throw error when unsupported models are initialized

### DIFF
--- a/test/test_model.py
+++ b/test/test_model.py
@@ -8,6 +8,20 @@ from litgpt.model import GPT as LitGPT
 from whittle.exceptions import IllegalSubNetworkError
 from whittle.models.gpt import GPT
 
+MoE_MODEL_NAMES = [
+    "Qwen3-235B-A22B",
+    "Qwen3-235B-A22B-Instruct-2507",
+    "Qwen3-235B-A22B-Thinking-2507",
+    "Qwen3-30B-A3B",
+    "Qwen3-30B-A3B-Base",
+    "Qwen3-30B-A3B-Instruct-2507",
+    "Qwen3-30B-A3B-Thinking-2507",
+    "Mixtral-8x22B-Instruct-v0.1",
+    "Mixtral-8x22B-v0.1",
+    "Mixtral-8x7B-Instruct-v0.1",
+    "Mixtral-8x7B-v0.1",
+]
+
 
 def get_default_test_config():
     config = Config()
@@ -168,6 +182,16 @@ def test_gpt():
         ]
     out_lit_small = lit_gpt_small(input)
     assert torch.allclose(out_lit_small, out_small, atol=1e-3)
+
+
+@pytest.mark.parametrize("model_name", MoE_MODEL_NAMES)
+def test_unsupported_models(model_name):
+    config = Config.from_name(model_name)
+
+    with pytest.raises(
+        ValueError, match="Mixture of Experts models are not currently supported."
+    ):
+        GPT(config)
 
 
 def copy_weights(model_source, model_target):

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -194,6 +194,16 @@ def test_unsupported_models(model_name):
         GPT(config)
 
 
+def test_unsupported_latent_attention_models():
+    config = get_default_test_config()
+    config.latent_attention = {"num_latent_tokens": 16}
+
+    with pytest.raises(
+        ValueError, match="Latent Attention models are not currently supported."
+    ):
+        GPT(config)
+
+
 def copy_weights(model_source, model_target):
     for (_, p1), (_, p2) in zip(
         model_source.named_parameters(), model_target.named_parameters()

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -185,7 +185,7 @@ def test_gpt():
 
 
 @pytest.mark.parametrize("model_name", MoE_MODEL_NAMES)
-def test_unsupported_models(model_name):
+def test_unsupported_moe_models(model_name):
     config = Config.from_name(model_name)
 
     with pytest.raises(

--- a/whittle/models/gpt/model.py
+++ b/whittle/models/gpt/model.py
@@ -33,6 +33,9 @@ class GPT(nn.Module):
     """An extension of litgpt's GPT model with support to adapt to sub-network dimensionality."""
 
     def __init__(self, config: Config) -> None:
+        if config.n_expert > 0:
+            raise ValueError("Mixture of Experts models are not currently supported.")
+
         super().__init__()
         assert config.padded_vocab_size is not None
         self.config = config

--- a/whittle/models/gpt/model.py
+++ b/whittle/models/gpt/model.py
@@ -29,12 +29,18 @@ from whittle.modules.linear import Linear
 from whittle.modules.rmsnorm import RMSNorm
 
 
+def assert_config_is_supported(config: Config):
+    if config.n_expert > 0:
+        raise ValueError("Mixture of Experts models are not currently supported.")
+    if config.latent_attention is not None:
+        raise ValueError("Latent Attention models are not currently supported.")
+
+
 class GPT(nn.Module):
     """An extension of litgpt's GPT model with support to adapt to sub-network dimensionality."""
 
     def __init__(self, config: Config) -> None:
-        if config.n_expert > 0:
-            raise ValueError("Mixture of Experts models are not currently supported.")
+        assert_config_is_supported(config)
 
         super().__init__()
         assert config.padded_vocab_size is not None


### PR DESCRIPTION
#### Reference Issues/PRs
This PR prevents users from instantiating Whittle models which:
1. Use MoE models
2. Use Latent Attention

#### Minimal Example / How should this PR be tested?
Run the tests:
```
pytest test/test_model.py -k test_unsupported_moe_models
pytest test/test_model.py -k test_unsupported_latent_attention_models
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.