### PR TITLE
fix: fix qk normalization in attention layers

### DIFF
--- a/test/test_model.py
+++ b/test/test_model.py
@@ -204,6 +204,21 @@ def test_unsupported_latent_attention_models():
         GPT(config)
 
 
+def _halved_subnet_config(config):
+    return {
+        "sub_network_n_embd": max(1, config.n_embd // 2),
+        "sub_network_intermediate_size": max(1, config.intermediate_size // 2),
+        "sub_network_num_heads": max(1, config.n_head // 2),
+        "sub_network_n_layers": max(1, config.n_layer // 2),
+        "sub_network_query_groups": max(1, config.n_query_groups // 2),
+        "sub_network_head_size": config.head_size,
+    }
+
+
+def _count_params(model):
+    return sum(p.numel() for p in model.parameters())
+
+
 def copy_weights(model_source, model_target):
     for (_, p1), (_, p2) in zip(
         model_source.named_parameters(), model_target.named_parameters()
@@ -222,11 +237,18 @@ def test_llama_3_1():
     config_llama.fix_head_size = True
     lit_model = LitGPT(config_llama)
     whittle_model = GPT(config_llama)
+
+    assert _count_params(whittle_model) == _count_params(lit_model)
+
     copy_weights(lit_model, whittle_model)
     x = torch.tensor([[9856, 23, 491, 1536, 304]], dtype=torch.int32)
     whittle_out = whittle_model(x)
     lit_out = lit_model(x)
     assert torch.allclose(whittle_out, lit_out, atol=1e-3)
+
+    whittle_model.reset_super_network()
+    whittle_model.set_sub_network(**_halved_subnet_config(config_llama))
+    whittle_model(x)
 
 
 def test_llama_3_2():
@@ -240,11 +262,18 @@ def test_llama_3_2():
     config_llama.fix_head_size = True
     lit_model = LitGPT(config_llama)
     whittle_model = GPT(config_llama)
+
+    assert _count_params(whittle_model) == _count_params(lit_model)
+
     copy_weights(lit_model, whittle_model)
     x = torch.tensor([[9856, 23, 491, 1536, 304]], dtype=torch.int32)
     whittle_out = whittle_model(x)
     lit_out = lit_model(x)
     assert torch.allclose(whittle_out, lit_out, atol=1e-3)
+
+    whittle_model.reset_super_network()
+    whittle_model.set_sub_network(**_halved_subnet_config(config_llama))
+    whittle_model(x)
 
 
 def test_gemma_2():
@@ -259,11 +288,18 @@ def test_gemma_2():
     config_gemma.fix_head_size = True
     lit_model = LitGPT(config_gemma)
     whittle_model = GPT(config_gemma)
+
+    assert _count_params(whittle_model) == _count_params(lit_model)
+
     copy_weights(lit_model, whittle_model)
     x = torch.tensor([[9856, 23, 491, 1536, 304, 1234]], dtype=torch.int32)
     whittle_out = whittle_model(x)
     lit_out = lit_model(x)
     assert torch.allclose(whittle_out, lit_out, atol=1e-3)
+
+    whittle_model.reset_super_network()
+    whittle_model.set_sub_network(**_halved_subnet_config(config_gemma))
+    whittle_model(x)
 
 
 def test_gemma_3():
@@ -278,11 +314,43 @@ def test_gemma_3():
     config_gemma.fix_head_size = True
     lit_model = LitGPT(config_gemma)
     whittle_model = GPT(config_gemma)
+
+    assert _count_params(whittle_model) == _count_params(lit_model)
+
     copy_weights(lit_model, whittle_model)
     x = torch.tensor([[9856, 23, 491, 1536, 304, 1234]], dtype=torch.int32)
     whittle_out = whittle_model(x)
     lit_out = lit_model(x)
     assert torch.allclose(whittle_out, lit_out, atol=1e-3)
+
+    whittle_model.reset_super_network()
+    whittle_model.set_sub_network(**_halved_subnet_config(config_gemma))
+    whittle_model(x)
+
+
+def test_olmo_2():
+    config_olmo = Config.from_name(
+        "OLMo-2-1124-7B",
+        block_size=6,
+        n_layer=1,
+        n_embd=32,
+        intermediate_size=86,
+    )
+    config_olmo.fix_head_size = True
+    lit_model = LitGPT(config_olmo)
+    whittle_model = GPT(config_olmo)
+
+    assert _count_params(whittle_model) == _count_params(lit_model)
+
+    copy_weights(lit_model, whittle_model)
+    x = torch.tensor([[9856, 23, 491, 1536, 304, 1234]], dtype=torch.int32)
+    whittle_out = whittle_model(x)
+    lit_out = lit_model(x)
+    assert torch.allclose(whittle_out, lit_out, atol=1e-3)
+
+    whittle_model.reset_super_network()
+    whittle_model.set_sub_network(**_halved_subnet_config(config_olmo))
+    whittle_model(x)
 
 
 def test_qwen_3():
@@ -298,11 +366,18 @@ def test_qwen_3():
     config_qwen.fix_head_size = True
     lit_model = LitGPT(config_qwen)
     whittle_model = GPT(config_qwen)
+
+    assert _count_params(whittle_model) == _count_params(lit_model)
+
     copy_weights(lit_model, whittle_model)
     x = torch.tensor([[9856, 23, 491, 1536, 304]], dtype=torch.int32)
     whittle_out = whittle_model(x)
     lit_out = lit_model(x)
     assert torch.allclose(whittle_out, lit_out, atol=1e-4)
+
+    whittle_model.reset_super_network()
+    whittle_model.set_sub_network(**_halved_subnet_config(config_qwen))
+    whittle_model(x)
 
 
 def get_default_illegal_test_config():

--- a/whittle/models/gpt/blocks/causal_self_attention.py
+++ b/whittle/models/gpt/blocks/causal_self_attention.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import math
+from functools import partial
 from typing import Any
 
 import torch
@@ -11,6 +12,8 @@ from litgpt.scripts.convert_hf_checkpoint import qkv_reassemble
 
 from whittle.exceptions import IllegalSubNetworkError
 from whittle.modules import Linear
+from whittle.modules.layernorm import LayerNorm
+from whittle.modules.rmsnorm import RMSNorm
 
 
 class CausalSelfAttention(nn.Module):
@@ -47,8 +50,9 @@ class CausalSelfAttention(nn.Module):
                 if config.norm_qk_type == "olmo2"
                 else config.head_size
             )
-            self.norm_q = config.norm_class(norm_q_size, eps=config.norm_eps)
-            self.norm_k = config.norm_class(norm_k_size, eps=config.norm_eps)
+            norm_class = self.norm_class()
+            self.norm_q = norm_class(norm_q_size, eps=config.norm_eps)
+            self.norm_k = norm_class(norm_k_size, eps=config.norm_eps)
         else:
             self.norm_q = self.norm_k = None
         # Set current sub-network to super-network
@@ -64,6 +68,19 @@ class CausalSelfAttention(nn.Module):
             self.sub_network_n_head // self.sub_network_query_groups
         )
         self.sub_attention_scaler = self.config.attention_scores_scalar
+
+    def norm_class(self):
+        # `self._norm_class` cannot be the type to keep the config json serializable
+        if self.config.norm_class_name == "RMSNorm":
+            return partial(RMSNorm, add_unit_offset="Gemma" in self.config.name)
+
+        if self.config.norm_class_name == "LayerNorm" and "OLMo" in self.config.name:
+            # this makes it equivalent to `torch.nn.functional.layer_norm`
+            # that is used by OLMo
+            # Table 5 caption in the OLMo paper shows this - https://aclanthology.org/2024.acl-long.841
+            return partial(torch.nn.LayerNorm, elementwise_affine=False)
+
+        return LayerNorm
 
     def _verify_subnet_is_legal(
         self,

--- a/whittle/models/gpt/model.py
+++ b/whittle/models/gpt/model.py
@@ -89,6 +89,13 @@ class GPT(nn.Module):
         # `self._norm_class` cannot be the type to keep the config json serializable
         if self.config.norm_class_name == "RMSNorm":
             return partial(RMSNorm, add_unit_offset="Gemma" in self.config.name)
+
+        if self.config.norm_class_name == "LayerNorm" and "OLMo" in self.config.name:
+            # this makes it equivalent to `torch.nn.functional.layer_norm`
+            # that is used by OLMo
+            # Table 5 caption in the OLMo paper shows this - https://aclanthology.org/2024.acl-long.841
+            return partial(torch.nn.LayerNorm, elementwise_affine=False)
+
         return LayerNorm
 
     @property

--- a/whittle/modules/embedding.py
+++ b/whittle/modules/embedding.py
@@ -20,15 +20,15 @@ class Embedding(torch.nn.Embedding):
         dtype=None,
     ) -> None:
         super().__init__(
-            num_embeddings,
-            embedding_dim,
-            padding_idx,
-            max_norm,
-            norm_type,
-            scale_grad_by_freq,
-            sparse,
-            device,
-            dtype,
+            num_embeddings=num_embeddings,
+            embedding_dim=embedding_dim,
+            padding_idx=padding_idx,
+            max_norm=max_norm,
+            norm_type=norm_type,
+            scale_grad_by_freq=scale_grad_by_freq,
+            sparse=sparse,
+            device=device,
+            dtype=dtype,
         )
 
         # the embedding dimensionality of the current sub-network

--- a/whittle/modules/layernorm.py
+++ b/whittle/modules/layernorm.py
@@ -7,8 +7,23 @@ import torch.nn.functional as F
 class LayerNorm(torch.nn.LayerNorm):
     """An extension of PyTorch's `torch.nn.LayerNorm` with support  with support to sub-sample weights corresponding to the sub-network dimensionality."""
 
-    def __init__(self, in_features: int, eps: float = 1e-5):
-        super().__init__(in_features, eps)
+    def __init__(
+        self,
+        in_features: int,
+        eps: float = 1e-5,
+        elementwise_affine: bool = True,
+        bias: bool = True,
+        device=None,
+        dtype=None,
+    ):
+        super().__init__(
+            normalized_shape=in_features,
+            eps=eps,
+            elementwise_affine=elementwise_affine,
+            bias=bias,
+            device=device,
+            dtype=dtype,
+        )
         self.in_features = in_features
 
         # Set current sub-network to super-network

--- a/whittle/modules/linear.py
+++ b/whittle/modules/linear.py
@@ -16,7 +16,13 @@ class Linear(nn.Linear):
         device=None,
         dtype=None,
     ):
-        super().__init__(in_features, out_features, bias, device, dtype)
+        super().__init__(
+            in_features=in_features,
+            out_features=out_features,
+            bias=bias,
+            device=device,
+            dtype=dtype,
+        )
 
         # Set the current sub-network dimensions equal to super-network
         self.sub_network_in_features = in_features


### PR DESCRIPTION
#### Reference Issues/PRs
This PR resolves #364 

#### What does this implement/fix? Explain your changes.
This PR consumes the Whittle normalization modules in the q/k normalization layers inside `CausalSelfAttention`, thereby supporting Whittle APIs.

#### Minimal Example / How should this PR be tested?
`pytest test/test_models.py`

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.