### PR TITLE
fix: fix conversion of model to LitGPT

### DIFF
--- a/test/test_convert_to_litgpt.py
+++ b/test/test_convert_to_litgpt.py
@@ -13,6 +13,17 @@ from whittle.convert import convert_subnet_to_litgpt
 from whittle.models.gpt import GPT
 
 
+def _halved_subnet_config(config):
+    return {
+        "sub_network_n_embd": max(1, config.n_embd // 2),
+        "sub_network_intermediate_size": max(1, config.intermediate_size // 2),
+        "sub_network_num_heads": max(1, config.n_head // 2),
+        "sub_network_n_layers": max(1, config.n_layer // 2),
+        "sub_network_query_groups": max(1, config.n_query_groups // 2),
+        "sub_network_head_size": config.head_size,
+    }
+
+
 @pytest.fixture(scope="session")
 def supernet():
     model_id = "EleutherAI/pythia-14m"
@@ -48,3 +59,38 @@ def test_equivalence(supernet, search_space_type, config_id):
     lit_out = lit_model(x)
 
     assert torch.allclose(out_whittle, lit_out)
+
+
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "Llama-3-8B",
+        # "gemma-2-9b", # TODO: Fix
+        # "gemma-3-1b-it", # TODO: Fix
+        "OLMo-2-1124-7B",
+        "Qwen3-0.6B",
+    ],
+)
+def test_halved_subnet_matches_converted_litgpt(model_name):
+    config = Config.from_name(
+        model_name,
+        n_layer=2,
+        n_embd=32,
+        intermediate_size=86,
+        padded_vocab_size=10000,
+    )
+    config.fix_head_size = True
+
+    whittle_model = GPT(config)
+    whittle_model.eval()
+
+    subnet_config = _halved_subnet_config(config)
+    lit_model = convert_subnet_to_litgpt(whittle_model, subnet_config)
+    lit_model.eval()
+
+    x = torch.tensor([[9856, 23, 491, 1536, 304]], dtype=torch.int32)
+    whittle_model.set_sub_network(**subnet_config)
+    out_whittle = whittle_model(x)
+    out_lit = lit_model(x)
+
+    assert torch.allclose(out_whittle, out_lit, atol=1e-6)

--- a/test/test_convert_to_litgpt.py
+++ b/test/test_convert_to_litgpt.py
@@ -65,8 +65,8 @@ def test_equivalence(supernet, search_space_type, config_id):
     "model_name",
     [
         "Llama-3-8B",
-        # "gemma-2-9b", # TODO: Fix
-        # "gemma-3-1b-it", # TODO: Fix
+        "gemma-2-9b",
+        "gemma-3-1b-it",
         "OLMo-2-1124-7B",
         "Qwen3-0.6B",
     ],

--- a/whittle/convert.py
+++ b/whittle/convert.py
@@ -50,6 +50,9 @@ def copy_weights_to_litgpt(whittle_model, lit_model):
         _copy_weights_and_biases(whittle_block.norm_1, litgpt_block.norm_1)
         _copy_weights_and_biases(whittle_block.attn.qkv, litgpt_block.attn.qkv)
         _copy_weights_and_biases(whittle_block.attn.proj, litgpt_block.attn.proj)
+        if whittle_block.attn.config.norm_qk:
+            _copy_weights_and_biases(whittle_block.attn.norm_q, litgpt_block.attn.norm_q)
+            _copy_weights_and_biases(whittle_block.attn.norm_k, litgpt_block.attn.norm_k)
         _copy_weights_and_biases(
             whittle_block.post_attention_norm, litgpt_block.post_attention_norm
         )

--- a/whittle/convert.py
+++ b/whittle/convert.py
@@ -15,6 +15,13 @@ def create_litgpt_config_for_subnet(supernet):
     config.head_size = supernet.sub_network_head_size
     config.rope_n_elem = supernet.sub_network_rope_n_elem
     config.n_query_groups = supernet.sub_network_query_groups
+    # Whittle's attention recomputes the softmax scaler from the sub-network
+    # dimensions when `attention_scores_scalar` is set; mirror that so the
+    # converted LitGPT model uses the same scale.
+    if supernet.config.attention_scores_scalar:
+        config.attention_scores_scalar = (
+            supernet.sub_network_n_embd // supernet.sub_network_num_heads
+        )
     return config
 
 
@@ -26,7 +33,13 @@ def copy_weights_to_litgpt(whittle_model, lit_model):
             print(f"{whittle_module} has no method extract_weights")
 
         if hasattr(lit_module, "weight"):
-            lit_module.weight.data = W.data
+            w_data = W.data
+            # Whittle's RMSNorm.extract_weights folds `add_unit_offset` into the
+            # returned weight, but LitGPT's RMSNorm re-applies `(1 + weight)` in
+            # forward — subtract 1 to avoid applying the offset twice.
+            if getattr(lit_module, "add_unit_offset", False):
+                w_data = w_data - 1
+            lit_module.weight.data = w_data
 
         if hasattr(lit_module, "bias"):
             if b is None:

--- a/whittle/modules/rmsnorm.py
+++ b/whittle/modules/rmsnorm.py
@@ -42,7 +42,7 @@ class RMSNorm(torch.nn.Module):
         self.sub_network_in_features = self.in_features
         self.sampled_ln_indices = None
 
-    def extract_weights(self) -> torch.Tensor:
+    def extract_weights(self) -> tuple[torch.Tensor, None]:
         if self.sampled_ln_indices is not None:
             weight = (
                 (1 + self.weight[self.sampled_ln_indices])

--- a/whittle/modules/rmsnorm.py
+++ b/whittle/modules/rmsnorm.py
@@ -42,7 +42,7 @@ class RMSNorm(torch.nn.Module):
         self.sub_network_in_features = self.in_features
         self.sampled_ln_indices = None
 
-    def extract_weight(self) -> torch.Tensor:
+    def extract_weights(self) -> torch.Tensor:
         if self.sampled_ln_indices is not None:
             weight = (
                 (1 + self.weight[self.sampled_ln_indices])
@@ -67,7 +67,7 @@ class RMSNorm(torch.nn.Module):
         # NOTE: the original RMSNorm paper implementation is not equivalent
         norm_x = torch.mean(x * x, dim=self.dim, keepdim=True)
         x_normed = x * torch.rsqrt(norm_x + self.eps)
-        weight, _ = self.extract_weight()
+        weight, _ = self.extract_weights()
         return (x_normed * weight.float()).to(dtype=dtype)
 
     def reset_parameters(self) -> None:


### PR DESCRIPTION
#### Reference Issues/PRs

This PR resolves #366 

#### What does this implement/fix? Explain your changes.

Fixes four bugs in `whittle/convert.py` that caused the converted LitGPT model to produce outputs different from the whittle sub-network it was converted from:

1. **RMSNorm.extract_weight** was renamed to  **RMSNorm.extract_weights**

2. **Missing QK-norm copy** (affects OLMo-2, Qwen3, Gemma-3). `copy_weights_to_litgpt` did not touch `attn.norm_q` / `attn.norm_k`, so whenever `config.norm_qk=True` the LitGPT side ran with freshly-initialized QK-norm weights. Now copied in the per-block loop guarded by `whittle_block.attn.config.norm_qk`.

3. **Double unit-offset in RMSNorm** (affects Gemma-2, Gemma-3). Whittle's `RMSNorm.extract_weights()` folds `(1 + w)` into the returned tensor when `add_unit_offset=True`; LitGPT's `RMSNorm.forward` then re-applies `(1 + weight)` at runtime, so the effective weight became `(2 + w)`. `copy_weights_to_litgpt` now subtracts `1` before writing into any target module with `add_unit_offset=True`, cancelling the double offset.

4. **Stale `attention_scores_scalar` in the converted config** (affects Gemma-2, Gemma-3). Whittle's attention recomputes `sub_attention_scaler = sub_network_n_embd // sub_network_n_head` when `attention_scores_scalar` is set, but `create_litgpt_config_for_subnet` left the supernet's scaler (e.g. `256` for Gemma-2-9b) in the converted config, so softmax was scaled by `1/sqrt(256)` on the LitGPT side vs `1/sqrt(n_embd // n_head)` on the whittle side. Now mirrored in the converted config.

Also adds a parameterized regression test `test/test_convert_to_litgpt.py::test_halved_subnet_matches_converted_litgpt` that, for each of Llama-3-8B, gemma-2-9b, gemma-3-1b-it, OLMo-2-1124-7B, and Qwen3-0.6B:

1. Builds a whittle `GPT`,
2. Halves it via the `_halved_subnet_config` pattern already used in `test/test_model.py`,
3. Converts the sub-network to LitGPT with `convert_subnet_to_litgpt`,
4. Asserts `torch.allclose(out_whittle, out_lit, atol=1e-6)`.

#### Minimal Example / How should this PR be tested?

```bash
pytest test/test_convert_to_litgpt.py::test_halved_subnet_matches_converted_litgpt -v
```

Expected: 5/5 parametrizations pass. Actual max absolute diff on all five is `0.0`.

Manual repro of the pre-fix bug on Gemma-2:

```python
import torch
from litgpt import Config
from whittle.convert import convert_subnet_to_litgpt
from whittle.models.gpt import GPT

config = Config.from_name(
    "gemma-2-9b", n_layer=2, n_embd=32, intermediate_size=86, padded_vocab_size=10000
)
config.fix_head_size = True
whittle_model = GPT(config).eval()
subnet = dict(
    sub_network_n_embd=16, sub_network_intermediate_size=43,
    sub_network_num_heads=8, sub_network_n_layers=1,
    sub_network_query_groups=4, sub_network_head_size=config.head_size,
)
lit = convert_subnet_to_litgpt(whittle_model, subnet).eval()
whittle_model.set_sub_network(**subnet)

x = torch.tensor([[9856, 23, 491, 1536, 304]], dtype=torch.int32)
assert torch.allclose(whittle_model(x), lit(x), atol=1e-6)
```

Pre-fix: `max_abs_diff ≈ 9.5e-01`. Post-fix: `0.0`.

#### Any other comments?

- The four bugs are independent. The first landed in the prior commit on this branch (`7a0bbd5`); the two Gemma fixes are in the second commit (`e02c75c`).
- No behaviour change for models without `norm_qk`, `add_unit_offset`, or `attention_scores_scalar` — the new code paths are all gated on those config flags.
- `create_litgpt_config_for_subnet` only mirrors the scaler when the supernet had one set; models that use the default `1/sqrt(head_size)` path are unaffected.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
