### PR TITLE
feat: add Whittle to Hugging Face checkpoint conversion

### DIFF
--- a/test/test_convert_to_hf.py
+++ b/test/test_convert_to_hf.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import pytest
+import torch
+from litgpt import Config
+from transformers.models.gemma2 import Gemma2Config, Gemma2ForCausalLM
+from transformers.models.gpt_neox import GPTNeoXConfig, GPTNeoXForCausalLM
+from transformers.models.llama import LlamaConfig, LlamaForCausalLM
+from transformers.models.qwen3 import Qwen3Config, Qwen3ForCausalLM
+
+from whittle.convert import save_as_hf_checkpoint
+from whittle.models.gpt import GPT
+
+
+def _qwen3_hf(cfg):
+    return Qwen3ForCausalLM(
+        Qwen3Config(
+            vocab_size=cfg.padded_vocab_size,
+            hidden_size=cfg.n_embd,
+            head_dim=cfg.head_size,
+            num_attention_heads=cfg.n_head,
+            num_hidden_layers=cfg.n_layer,
+            intermediate_size=cfg.intermediate_size,
+            num_key_value_heads=cfg.n_query_groups,
+            max_position_embeddings=cfg.block_size,
+            rms_norm_eps=cfg.norm_eps,
+            rope_theta=cfg.rope_base,
+            tie_word_embeddings=False,
+        )
+    )
+
+
+def _llama_hf(cfg):
+    return LlamaForCausalLM(
+        LlamaConfig(
+            vocab_size=cfg.padded_vocab_size,
+            hidden_size=cfg.n_embd,
+            head_dim=cfg.head_size,
+            num_attention_heads=cfg.n_head,
+            num_hidden_layers=cfg.n_layer,
+            intermediate_size=cfg.intermediate_size,
+            num_key_value_heads=cfg.n_query_groups,
+            max_position_embeddings=cfg.block_size,
+            rms_norm_eps=cfg.norm_eps,
+            rope_theta=cfg.rope_base,
+            tie_word_embeddings=False,
+        )
+    )
+
+
+def _gemma2_hf(cfg):
+    return Gemma2ForCausalLM(
+        Gemma2Config(
+            vocab_size=cfg.padded_vocab_size,
+            hidden_size=cfg.n_embd,
+            head_dim=cfg.head_size,
+            num_attention_heads=cfg.n_head,
+            num_hidden_layers=cfg.n_layer,
+            intermediate_size=cfg.intermediate_size,
+            num_key_value_heads=cfg.n_query_groups,
+            max_position_embeddings=cfg.block_size,
+            sliding_window=cfg.sliding_window_size,
+            rms_norm_eps=cfg.norm_eps,
+            rope_theta=cfg.rope_base,
+            attention_bias=cfg.bias,
+            tie_word_embeddings=True,
+            hidden_act="gelu_pytorch_tanh",
+            attn_logit_softcapping=cfg.attention_logit_softcapping,
+            final_logit_softcapping=cfg.final_logit_softcapping,
+            attn_implementation="eager",
+            query_pre_attn_scalar=cfg.attention_scores_scalar,
+        )
+    )
+
+
+def _pythia_hf(cfg):
+    return GPTNeoXForCausalLM(
+        GPTNeoXConfig(
+            hidden_act="gelu",
+            hidden_size=cfg.n_embd,
+            num_attention_heads=cfg.n_head,
+            num_hidden_layers=cfg.n_layer,
+            intermediate_size=cfg.intermediate_size,
+            max_position_embeddings=cfg.block_size,
+            rotary_emb_base=cfg.rope_base,
+            rotary_pct=cfg.rotary_percentage,
+            vocab_size=cfg.padded_vocab_size,
+            use_parallel_residual=cfg.parallel_residual,
+        )
+    )
+
+
+MODEL_CASES = [
+    pytest.param(
+        "Qwen3-0.6B",
+        dict(block_size=10, n_layer=2, n_head=16, n_embd=32, intermediate_size=86),
+        _qwen3_hf,
+        False,
+        id="Qwen3-0.6B",
+    ),
+    pytest.param(
+        "Llama-3-8B",
+        dict(
+            block_size=10,
+            n_layer=2,
+            n_embd=32,
+            intermediate_size=86,
+            padded_vocab_size=10000,
+        ),
+        _llama_hf,
+        False,
+        id="Llama-3-8B",
+    ),
+    pytest.param(
+        "gemma-2-9b",
+        dict(
+            block_size=6,
+            sliding_window_size=3,
+            n_layer=2,
+            n_embd=32,
+            intermediate_size=86,
+        ),
+        _gemma2_hf,
+        True,
+        id="gemma-2-9b",
+    ),
+    pytest.param(
+        "pythia-14m",
+        dict(block_size=10, n_layer=2, n_head=4, n_embd=32, intermediate_size=128),
+        _pythia_hf,
+        False,
+        id="pythia-14m",
+    ),
+]
+
+
+@torch.inference_mode()
+@pytest.mark.parametrize("model_name,config_kwargs,hf_builder,ties", MODEL_CASES)
+def test_whittle_to_hf_matches(tmp_path, model_name, config_kwargs, hf_builder, ties):
+    # 1) Load a small whittle model
+    config = Config.from_name(model_name, **config_kwargs)
+    config.fix_head_size = True
+    whittle_model = GPT(config)
+    if ties:
+        whittle_model.lm_head.weight = whittle_model.transformer.wte.weight
+    whittle_model.eval()
+
+    # 2) Halve sub-network dimensions
+    sub_network_config = {
+        "embed_dim": config.n_embd // 2,
+        "mlp_ratio": (config.intermediate_size // 2) / (config.n_embd // 2),
+        "num_heads": config.n_head // 2,
+        "depth": config.n_layer // 2,
+        "n_query_groups": config.n_query_groups // 2,
+        "head_size": config.head_size,
+    }
+
+    # 3) Save as a Hugging Face checkpoint
+    save_as_hf_checkpoint(
+        whittle_model, sub_network_config=sub_network_config, out_dir=tmp_path
+    )
+
+    # 4) Load the HF model
+    sub_cfg = Config.from_file(tmp_path / "model_config.yaml")
+    hf_model = hf_builder(sub_cfg)
+    hf_model.load_state_dict(
+        torch.load(tmp_path / "model.pth", weights_only=True), strict=False
+    )
+    hf_model.eval()
+
+    if ties:
+        # save_as_hf_checkpoint resets the super-net and drops tying.
+        whittle_model.lm_head.weight = whittle_model.transformer.wte.weight
+
+    # 5) Compare outputs
+    x = torch.tensor([[9856, 23, 491, 1536, 304]], dtype=torch.int32)
+    whittle_model.set_sub_network(
+        sub_network_n_embd=sub_cfg.n_embd,
+        sub_network_intermediate_size=sub_cfg.intermediate_size,
+        sub_network_num_heads=sub_cfg.n_head,
+        sub_network_n_layers=sub_cfg.n_layer,
+        sub_network_query_groups=sub_cfg.n_query_groups,
+        sub_network_head_size=sub_cfg.head_size,
+    )
+    out_whittle = whittle_model(x)
+    out_hf = hf_model(x)["logits"]
+
+    torch.testing.assert_close(out_whittle, out_hf, atol=1e-4, rtol=1e-4)

--- a/test/test_convert_to_hf.py
+++ b/test/test_convert_to_hf.py
@@ -93,7 +93,7 @@ def _pythia_hf(cfg):
 MODEL_CASES = [
     pytest.param(
         "Qwen3-0.6B",
-        dict(block_size=10, n_layer=2, n_head=16, n_embd=32, intermediate_size=86),
+        dict(block_size=64, n_layer=16, n_head=16, n_embd=32, intermediate_size=86),
         _qwen3_hf,
         False,
         id="Qwen3-0.6B",
@@ -101,8 +101,8 @@ MODEL_CASES = [
     pytest.param(
         "Llama-3-8B",
         dict(
-            block_size=10,
-            n_layer=2,
+            block_size=64,
+            n_layer=16,
             n_embd=32,
             intermediate_size=86,
             padded_vocab_size=10000,
@@ -114,9 +114,9 @@ MODEL_CASES = [
     pytest.param(
         "gemma-2-9b",
         dict(
-            block_size=6,
+            block_size=64,
             sliding_window_size=3,
-            n_layer=2,
+            n_layer=16,
             n_embd=32,
             intermediate_size=86,
         ),
@@ -126,7 +126,7 @@ MODEL_CASES = [
     ),
     pytest.param(
         "pythia-14m",
-        dict(block_size=10, n_layer=2, n_head=4, n_embd=32, intermediate_size=128),
+        dict(block_size=64, n_layer=16, n_head=4, n_embd=32, intermediate_size=128),
         _pythia_hf,
         False,
         id="pythia-14m",
@@ -173,7 +173,9 @@ def test_whittle_to_hf_matches(tmp_path, model_name, config_kwargs, hf_builder, 
         whittle_model.lm_head.weight = whittle_model.transformer.wte.weight
 
     # 5) Compare outputs
-    x = torch.tensor([[9856, 23, 491, 1536, 304]], dtype=torch.int32)
+    x = torch.randint(
+        0, config.n_embd, size=(2, 64)
+    )  # use random input to avoid hitting tied weights
     whittle_model.set_sub_network(
         sub_network_n_embd=sub_cfg.n_embd,
         sub_network_intermediate_size=sub_cfg.intermediate_size,
@@ -185,4 +187,4 @@ def test_whittle_to_hf_matches(tmp_path, model_name, config_kwargs, hf_builder, 
     out_whittle = whittle_model(x)
     out_hf = hf_model(x)["logits"]
 
-    torch.testing.assert_close(out_whittle, out_hf, atol=1e-4, rtol=1e-4)
+    torch.testing.assert_close(out_whittle, out_hf, atol=1e-6, rtol=1e-6)

--- a/whittle/convert.py
+++ b/whittle/convert.py
@@ -1,8 +1,19 @@
 from __future__ import annotations
 
 import copy
+import tempfile
+from pathlib import Path
+from typing import Any
 
+import torch
+from litgpt import Config
 from litgpt.model import GPT as LitGPT
+from litgpt.scripts.convert_lit_checkpoint import convert_lit_checkpoint
+from litgpt.utils import save_config
+
+from whittle.convert_to_litgpt import setup as convert_to_litgpt_setup
+from whittle.models.gpt import GPT
+from whittle.models.gpt.checkpoint import save_sub_network
 
 
 def create_litgpt_config_for_subnet(supernet):
@@ -89,3 +100,64 @@ def convert_subnet_to_litgpt(whittle_model, subnet_config):
     copy_weights_to_litgpt(whittle_model, lit_model)
     whittle_model.reset_super_network()
     return lit_model
+
+
+def save_as_hf_checkpoint(
+    whittle_model: GPT,
+    sub_network_config: dict[str, Any],
+    out_dir: Path | str,
+) -> None:
+    """
+    Convert a Whittle super-network + sub-network config into a Hugging Face
+    checkpoint on disk.
+
+    Staged internally through a temp directory:
+      1. Save the super-network as a parent LitGPT checkpoint.
+      2. Extract the sub-network with `save_sub_network` (format b).
+      3. Normalize to a plain LitGPT checkpoint via `whittle.convert_to_litgpt`.
+      4. Convert LitGPT -> HF via `litgpt.scripts.convert_lit_checkpoint`.
+
+    The final `out_dir` contains `model.pth` (HF state dict) and
+    `model_config.yaml` (the sub-network's LitGPT config).
+
+    Arguments:
+        whittle_model: The Whittle super-network to extract from.
+        sub_network_config: Sub-network config in the `select_sub_network`
+            schema (`embed_dim`, `mlp_ratio`, `num_heads`, `depth`,
+            `n_query_groups`, `head_size`).
+        out_dir: Directory to write the HF checkpoint into. Created if missing.
+    """
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = Path(tmp_str)
+        parent_dir = tmp / "parent"
+        parent_dir.mkdir()
+        save_config(whittle_model.config, parent_dir)
+        torch.save(whittle_model.state_dict(), parent_dir / "lit_model.pth")
+
+        subnet_dir = tmp / "subnet"
+        save_sub_network(
+            whittle_model,
+            checkpoint_dir=parent_dir,
+            save_dir=subnet_dir,
+            sub_network_config=sub_network_config,
+            save_checkpoints=True,
+            copy_config_files=False,
+        )
+        whittle_model.reset_super_network()
+
+        litgpt_dir = tmp / "litgpt"
+        litgpt_dir.mkdir()
+        convert_to_litgpt_setup(
+            sub_network_dir=subnet_dir,
+            out_dir=litgpt_dir,
+            no_model_key=True,
+        )
+
+        convert_lit_checkpoint(checkpoint_dir=litgpt_dir, output_dir=out_dir)
+
+        # Keep the sub-network's model_config.yaml alongside the HF weights so
+        # callers can reconstruct the matching HF config.
+        save_config(Config.from_file(litgpt_dir / "model_config.yaml"), out_dir)


### PR DESCRIPTION
#### Reference Issues/PRs

N/A

#### What does this implement/fix? Explain your changes.

Adds `whittle.convert.save_as_hf_checkpoint`, a programmatic API for converting a Whittle super-network + sub-network config into a Hugging Face checkpoint on disk.

The function stages everything through a `TemporaryDirectory`:

1. Save the super-network as a parent LitGPT checkpoint.
2. Extract the sub-network via `save_sub_network` (format b).
3. Normalize to a plain LitGPT checkpoint via
   `whittle.convert_to_litgpt`.
4. Convert LitGPT → HF via
   `litgpt.scripts.convert_lit_checkpoint.convert_lit_checkpoint`.

The final `out_dir` ends up with just `model.pth` (HF-style state dict) and `model_config.yaml` (the sub-network's LitGPT config, kept so that callers can reconstruct the matching HF config).

Also adds `test/test_convert_to_hf.py`, parametrized across Qwen3, Llama-3, Gemma-2, and Pythia. For each model it:

- Builds a small Whittle `GPT`.
- Halves its sub-network dimensions.
- Calls `save_as_hf_checkpoint`.
- Loads the converted `model.pth` into the appropriate
  `*ForCausalLM` (`Qwen3ForCausalLM`, `LlamaForCausalLM`,
  `Gemma2ForCausalLM`, `GPTNeoXForCausalLM`).
- Asserts the HF logits match the Whittle sub-network's logits.

The second commit bumps sequence length and layer count in the test configs (`block_size=10`, `n_layer=2`) to exercise multi-token and multi-layer forward passes end-to-end.

#### Minimal Example / How should this PR be tested?

```python
from litgpt import Config
from whittle.convert import save_as_hf_checkpoint
from whittle.models.gpt import GPT

config = Config.from_name("Qwen3-0.6B", n_layer=2, n_embd=32, intermediate_size=86)
config.fix_head_size = True
model = GPT(config)

sub_network_config = {
    "embed_dim": 16,
    "mlp_ratio": 43 / 16,
    "num_heads": 8,
    "depth": 1,
    "n_query_groups": 4,
    "head_size": config.head_size,
}

save_as_hf_checkpoint(model, sub_network_config=sub_network_config, out_dir="out/")
```

Run the new test suite:

```
pytest test/test_convert_to_hf.py -v
```

#### Any other comments?

- Gemma-3 and OLMo-2 are intentionally not covered by the new test. Both hit upstream bugs in `litgpt.scripts.convert_lit_checkpoint`:
  - Gemma-3 has no dispatch branch and falls through  `copy_weights_llama`, which doesn't map `post_attention_norm` /
    `post_mlp_norm`.
  - `copy_weights_olmo2`'s weight_map references `norm_2` but the
    actual state dict key is `post_attention_norm Both can be added once LitGPT is patched.
- For Gemma-2 the test ties `lm_head` to `transformer.wte` before saving and before the comparison forward pass, matching the `tie_word_embeddings=True` convention used by the HF model.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
