### PR TITLE
chore: deprecate config.fix_head_size

### DIFF
--- a/test/test_api.py
+++ b/test/test_api.py
@@ -183,7 +183,6 @@ class Test_WhittleLM:
     def test_logliklihood(self, checkpoint_dir, out_dir) -> None:
         device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
         config = Config.from_file(str(checkpoint_dir / "model_config.yaml"))
-        config.fix_head_size = True
         config.model_type = "gpt"
         config.tie_embeddings = False
         gpt = GPT(config).to(device)
@@ -208,7 +207,6 @@ class Test_WhittleLM:
     def test_generate_until(self, checkpoint_dir) -> None:
         device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
         config = Config.from_file(str(checkpoint_dir / "model_config.yaml"))
-        config.fix_head_size = True
         config.model_type = "gpt"
         config.tie_embeddings = False
         gpt = GPT(config).to(device)
@@ -223,7 +221,6 @@ class Test_WhittleLM:
     def test_logliklihood_rolling(self, checkpoint_dir) -> None:
         device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
         config = Config.from_file(str(checkpoint_dir / "model_config.yaml"))
-        config.fix_head_size = True
         config.model_type = "gpt"
         config.tie_embeddings = False
         gpt = GPT(config).to(device)
@@ -238,7 +235,6 @@ class Test_WhittleLM:
     def test_toc_encode(self, checkpoint_dir) -> None:
         device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
         config = Config.from_file(str(checkpoint_dir / "model_config.yaml"))
-        config.fix_head_size = True
         config.model_type = "gpt"
         config.tie_embeddings = False
         gpt = GPT(config).to(device)
@@ -253,7 +249,6 @@ class Test_WhittleLM:
     def test_toc_decode(self, checkpoint_dir) -> None:
         device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
         config = Config.from_file(str(checkpoint_dir / "model_config.yaml"))
-        config.fix_head_size = True
         config.model_type = "gpt"
         config.tie_embeddings = False
         gpt = GPT(config).to(device)
@@ -268,7 +263,6 @@ class Test_WhittleLM:
     def test_batch_encode(self, checkpoint_dir) -> None:
         device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
         config = Config.from_file(str(checkpoint_dir / "model_config.yaml"))
-        config.fix_head_size = True
         config.model_type = "gpt"
         config.tie_embeddings = False
         gpt = GPT(config).to(device)
@@ -283,7 +277,6 @@ class Test_WhittleLM:
     def test_model_generate(self, checkpoint_dir) -> None:
         device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
         config = Config.from_file(str(checkpoint_dir / "model_config.yaml"))
-        config.fix_head_size = True
         config.model_type = "gpt"
         config.tie_embeddings = False
         gpt = GPT(config).to(device)
@@ -300,7 +293,6 @@ class Test_WhittleLM:
     def test_evaluate(self, checkpoint_dir, out_dir):
         device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
         config = Config.from_file(str(checkpoint_dir / "model_config.yaml"))
-        config.fix_head_size = True
         config.model_type = "gpt"
         config.tie_embeddings = False
         gpt = GPT(config).to(device)
@@ -343,14 +335,12 @@ class Test_WhittleLM:
         torch.manual_seed(0)
         device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
         config = Config.from_file(str(checkpoint_dir / "model_config.yaml"))
-        config.fix_head_size = True
         config.model_type = "gpt"
         config.tie_embeddings = False
         gpt = GPT(config).to(device)
         gpt.name_or_path = "EleutherAI/pythia-70m"
         gpt.load_state_dict(torch.load(str(checkpoint_dir / "lit_model.pth")))
         config_14m = Config.from_file(str(checkpoint_dir_14m / "model_config.yaml"))
-        config_14m.fix_head_size = True
         config_14m.model_type = "gpt"
         config_14m.tie_embeddings = False
         gpt_14m = GPT(config_14m).to(device)

--- a/test/test_attention.py
+++ b/test/test_attention.py
@@ -12,43 +12,19 @@ from litgpt.model import (
 from whittle.models.gpt.blocks import CausalSelfAttention
 
 attention_configs = {
-    "mha_fix_head_size_sliding": {
-        "config": Config(
-            n_embd=64,
-            n_head=16,
-            n_query_groups=16,
-            head_size=64,
-            sliding_window_size=256,
-            n_layer=1,
-            # only layer with idx 0, 2, 4, ... have sliding window attention
-            sliding_window_indices=[1 if i % 2 == 0 else 0 for i in range(1)],
-        ),
-        "fix_head_size": True,
-    },
-    "mha_fix_head_size": {
-        "config": Config(n_embd=64, n_head=16, n_query_groups=16, head_size=64),
-        "fix_head_size": True,
-    },
-    "gqa_fix_head_size": {
-        "config": Config(n_embd=64, n_head=16, n_query_groups=2, head_size=64),
-        "fix_head_size": True,
-    },
-    "mqa_fix_head_size": {
-        "config": Config(n_embd=64, n_head=16, n_query_groups=1, head_size=64),
-        "fix_head_size": True,
-    },
-    "mha_flexible_head_size": {
-        "config": Config(n_embd=64, n_head=16, n_query_groups=16),
-        "fix_head_size": False,
-    },
-    "gqa_flexible_head_size": {
-        "config": Config(n_embd=64, n_head=16, n_query_groups=2),
-        "fix_head_size": False,
-    },
-    "mqa_flexible_head_size": {
-        "config": Config(n_embd=64, n_head=16, n_query_groups=1),
-        "fix_head_size": False,
-    },
+    "mha_sliding": Config(
+        n_embd=64,
+        n_head=16,
+        n_query_groups=16,
+        head_size=64,
+        sliding_window_size=256,
+        n_layer=1,
+        # only layer with idx 0, 2, 4, ... have sliding window attention
+        sliding_window_indices=[1 if i % 2 == 0 else 0 for i in range(1)],
+    ),
+    "mha": Config(n_embd=64, n_head=16, n_query_groups=16, head_size=64),
+    "gqa": Config(n_embd=64, n_head=16, n_query_groups=2, head_size=64),
+    "mqa": Config(n_embd=64, n_head=16, n_query_groups=1, head_size=64),
 }
 
 
@@ -101,10 +77,7 @@ def init_lit_small_attention(config, base_attention, attention_super):
 
 @pytest.mark.parametrize("attention_config", attention_configs.keys())
 def test_attention(attention_config):
-    config = attention_configs[attention_config]["config"]
-    config.fix_head_size = attention_configs[attention_config]["fix_head_size"]
-    if not config.fix_head_size:
-        config.head_size = 32
+    config = attention_configs[attention_config]
     config.max_seq_len = 512
     config.rope_n_elem = int(config.rotary_percentage * config.head_size)
 
@@ -122,10 +95,7 @@ def test_attention(attention_config):
     assert out_large.shape == (8, seq_len, config.n_embd)
     lit_attention = init_lit_attention(config)
     out_lit_large = lit_attention(input, mask=mask, cos=cos, sin=sin)
-    if not config.fix_head_size:
-        sub_network_head_size = config.head_size // 2
-    else:
-        sub_network_head_size = config.head_size
+    sub_network_head_size = config.head_size
     if config.n_query_groups == 1:
         sub_network_query_groups = 1
         sub_network_n_head = config.n_head // 4

--- a/test/test_checkpoint_loading.py
+++ b/test/test_checkpoint_loading.py
@@ -35,7 +35,6 @@ def test_checkpoint_loading(checkpoint_dir):
     # pip install litgpt
     # litgpt download --repo_id stabilityai/stablelm-base-alpha-3b
     config = Config.from_file(str(checkpoint_dir / "model_config.yaml"))
-    config.fix_head_size = False
     model = WhittleGPT(config)  # .cuda()
     model.load_state_dict(torch.load(str(checkpoint_dir / "lit_model.pth")))
     # test output

--- a/test/test_convert_to_hf.py
+++ b/test/test_convert_to_hf.py
@@ -139,7 +139,6 @@ MODEL_CASES = [
 def test_whittle_to_hf_matches(tmp_path, model_name, config_kwargs, hf_builder, ties):
     # 1) Load a small whittle model
     config = Config.from_name(model_name, **config_kwargs)
-    config.fix_head_size = True
     whittle_model = GPT(config)
     if ties:
         whittle_model.lm_head.weight = whittle_model.transformer.wte.weight

--- a/test/test_convert_to_litgpt.py
+++ b/test/test_convert_to_litgpt.py
@@ -36,7 +36,6 @@ def supernet():
         )
 
     config = Config.from_file(config_path)
-    config.fix_head_size = True
     supernet = GPT(config)
     return supernet
 
@@ -79,7 +78,6 @@ def test_halved_subnet_matches_converted_litgpt(model_name):
         intermediate_size=86,
         padded_vocab_size=10000,
     )
-    config.fix_head_size = True
 
     whittle_model = GPT(config)
     whittle_model.eval()

--- a/test/test_extract.py
+++ b/test/test_extract.py
@@ -14,11 +14,9 @@ from whittle.modules.rmsnorm import RMSNorm
 
 def test_extract_sub_network_mha() -> None:
     config = Config.from_name("pythia-70m")
-    config.fix_head_size = False
 
     super_network = GPT(config)
     sub_network_config = Config.from_name("pythia-14m")
-    sub_network_config.fix_head_size = False
 
     # set norm weights to random
     # the default is unit/zero vector which does not test the extract
@@ -53,7 +51,6 @@ def test_extract_sub_network_mha() -> None:
 
 def test_extract_sub_network_llamamlp_gqa() -> None:
     config = Config.from_name("micro-llama-300M")
-    config.fix_head_size = False
 
     super_network = GPT(config)
 
@@ -96,7 +93,6 @@ def test_extract_sub_network_llamamlp_gqa() -> None:
 
 def test_extract_sub_network_gemmamlp_mqa() -> None:
     config = Config.from_name("Gemma-2b")
-    config.fix_head_size = True
 
     # simulate a smaller network
     config.vocab_size = 256
@@ -143,7 +139,6 @@ def test_extract_sub_network_gemmamlp_mqa() -> None:
 
 def test_save_config() -> None:
     config = Config.from_name("micro-llama-300M")
-    config.fix_head_size = False
 
     super_network = GPT(config)
 

--- a/test/test_flops.py
+++ b/test/test_flops.py
@@ -25,7 +25,6 @@ def test_compute_flops(mlp_type, norm_type):
     config.rope_n_elem = int(config.rotary_percentage * config.head_size)
     config.norm_eps = 1e-5
     config.lm_head_bias = True
-    config.fix_head_size = True
     config.mlp_class_name = mlp_type
     config.norm_class_name = norm_type
 

--- a/test/test_mag.py
+++ b/test/test_mag.py
@@ -26,7 +26,6 @@ def test_compute_weight_magnitude(mlp_type, norm_type):
     config.rope_n_elem = int(config.rotary_percentage * config.head_size)
     config.norm_eps = 1e-5
     config.lm_head_bias = True
-    config.fix_head_size = True
     config.mlp_class_name = mlp_type
     config.norm_class_name = norm_type
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -38,7 +38,6 @@ def get_default_test_config():
     config.rope_n_elem = int(config.rotary_percentage * config.head_size)
     config.norm_eps = 1e-5
     config.lm_head_bias = True
-    config.fix_head_size = False
     return config
 
 
@@ -234,7 +233,6 @@ def test_llama_3_1():
         intermediate_size=86,
         padded_vocab_size=10000,
     )
-    config_llama.fix_head_size = True
     lit_model = LitGPT(config_llama)
     whittle_model = GPT(config_llama)
 
@@ -259,7 +257,6 @@ def test_llama_3_2():
         intermediate_size=86,
         padded_vocab_size=10000,
     )
-    config_llama.fix_head_size = True
     lit_model = LitGPT(config_llama)
     whittle_model = GPT(config_llama)
 
@@ -285,7 +282,6 @@ def test_gemma_2():
         n_embd=32,
         intermediate_size=86,
     )
-    config_gemma.fix_head_size = True
     lit_model = LitGPT(config_gemma)
     whittle_model = GPT(config_gemma)
 
@@ -311,7 +307,6 @@ def test_gemma_3():
         n_embd=32,
         intermediate_size=86,
     )
-    config_gemma.fix_head_size = True
     lit_model = LitGPT(config_gemma)
     whittle_model = GPT(config_gemma)
 
@@ -336,7 +331,6 @@ def test_olmo_2():
         n_embd=32,
         intermediate_size=86,
     )
-    config_olmo.fix_head_size = True
     lit_model = LitGPT(config_olmo)
     whittle_model = GPT(config_olmo)
 
@@ -363,7 +357,6 @@ def test_qwen_3():
         n_embd=32,
         intermediate_size=86,
     )
-    config_qwen.fix_head_size = True
     lit_model = LitGPT(config_qwen)
     whittle_model = GPT(config_qwen)
 

--- a/test/test_model_checkpoint.py
+++ b/test/test_model_checkpoint.py
@@ -42,7 +42,6 @@ def checkpoint_dir(tmp_path_factory):
     llama_dir.mkdir(parents=True, exist_ok=True)
     config = Config.from_name("micro-llama-300M")
     config.intermediate_size = 1024
-    config.fix_head_size = True
     save_config(config, llama_dir)
     model = GPT(config)
     random_init_weights(model)
@@ -55,7 +54,6 @@ def checkpoint_dir(tmp_path_factory):
     gemma_dir = checkpoint_dir / "google" / "gemma-2b"
     gemma_dir.mkdir(parents=True, exist_ok=True)
     config = Config.from_name("gemma-2b")
-    config.fix_head_size = True
     # simulate a smaller network
     config.vocab_size = 256
     config.n_embd = 32
@@ -95,7 +93,6 @@ def get_checkpoint_contents(copy_config_files, save_checkpoints):
 def test_checkpoints(tmp_path, checkpoint_dir, copy_config_files, save_checkpoints):
     checkpoint_dir = checkpoint_dir / "EleutherAI" / "pythia-14m"
     config = Config.from_file(str(checkpoint_dir / "model_config.yaml"))
-    config.fix_head_size = True
 
     model = GPT(config)
     ckp = lazy_load(checkpoint_dir / "lit_model.pth")
@@ -151,7 +148,6 @@ def test_checkpoints(tmp_path, checkpoint_dir, copy_config_files, save_checkpoin
             assert "parent_dir" in checkpoint
 
         loaded_model = load_checkpoint(out_dir)
-        assert loaded_model.config.fix_head_size is True  # by default this should be set
 
         model.select_sub_network(sub_network_dict)
 
@@ -180,7 +176,6 @@ def test_convert_to_litgpt(
     litgpt_dir.mkdir(exist_ok=True)
 
     config = Config.from_file(str(checkpoint_dir / "model_config.yaml"))
-    config.fix_head_size = True
 
     model = GPT(config)
     ckp = lazy_load(checkpoint_dir / "lit_model.pth")

--- a/test/test_parameters.py
+++ b/test/test_parameters.py
@@ -35,7 +35,6 @@ def test_compute_parameters_sub_network(mlp_type, norm_type):
     config.rope_n_elem = int(config.rotary_percentage * config.head_size)
     config.norm_eps = 1e-5
     config.lm_head_bias = True
-    config.fix_head_size = True
     config.mlp_class_name = mlp_type
     config.norm_class_name = norm_type
 

--- a/test/test_pruners.py
+++ b/test/test_pruners.py
@@ -28,7 +28,6 @@ def pruner_model(request, accelerator_device):
         n_embd=32,
         intermediate_size=86,
     )
-    config.fix_head_size = True
     config.model_type = "gpt"
     config.tie_embeddings = False
     config.use_cache = True

--- a/test/test_search_sub_network.py
+++ b/test/test_search_sub_network.py
@@ -27,7 +27,6 @@ def test_objective():
     model_config = Config(
         block_size=2, n_layer=2, n_embd=4, n_head=2, padded_vocab_size=8
     )
-    model_config.fix_head_size = True
 
     dataset = torch.tensor([[0, 1, 2], [3, 4, 5], [0, 1, 2]])
     dataloader = DataLoader(dataset)

--- a/test/test_training_strategies.py
+++ b/test/test_training_strategies.py
@@ -123,7 +123,6 @@ def test_integration_training_strategies_gpt(strategy, kd_loss):
     config.rope_n_elem = int(config.rotary_percentage * config.head_size)
     config.norm_eps = 1e-5
     config.lm_head_bias = True
-    config.fix_head_size = True
     gpt = GPT(config).to(device)
     inputs = torch.randint(0, 128, (1, 128)).to(device)
     outputs = torch.randn([1, 128, 128]).to(device)

--- a/test/test_transformer_block.py
+++ b/test/test_transformer_block.py
@@ -18,7 +18,6 @@ def test_block():
     config.n_query_groups = 4
     config.head_size = 8
     config.intermediate_size = 64 * 4
-    config.fix_head_size = False
     config.mlp_class_name = "LLaMAMLP"
     config.max_seq_len = 512
     config.rotary_percentage = 0.25

--- a/whittle/convert.py
+++ b/whittle/convert.py
@@ -18,7 +18,6 @@ from whittle.models.gpt.checkpoint import save_sub_network
 
 def create_litgpt_config_for_subnet(supernet):
     config = copy.deepcopy(supernet.config)
-    config.fix_head_size = True
     config.n_embd = supernet.sub_network_n_embd
     config.intermediate_size = supernet.sub_network_intermediate_size
     config.n_head = supernet.sub_network_num_heads

--- a/whittle/convert_to_litgpt.py
+++ b/whittle/convert_to_litgpt.py
@@ -101,7 +101,6 @@ def setup(
 
         # instantiate the super-network
         config = Config.from_file(model_path.parent / "model_config.yaml")
-        config.fix_head_size = True
         model = super_network_cls(config)
 
         # set the sub-network via the saved sub-network config

--- a/whittle/distill.py
+++ b/whittle/distill.py
@@ -116,7 +116,6 @@ def setup(
     if teacher_checkpoint_dir is not None:
         print(f"Loading teacher model config from {teacher_checkpoint_dir}")
         teacher_config = Config.from_file(teacher_checkpoint_dir / "model_config.yaml")
-        teacher_config.fix_head_size = True
     else:
         raise ValueError("teacher_checkpoint_dir is required")
 

--- a/whittle/evaluate_network.py
+++ b/whittle/evaluate_network.py
@@ -49,7 +49,6 @@ def setup(
     metrics_path.parent.mkdir(parents=True, exist_ok=True)
 
     config_attr = {
-        "fix_head_size": True,
         "model_type": "gpt",
         "tie_embeddings": False,
     }

--- a/whittle/full_finetune.py
+++ b/whittle/full_finetune.py
@@ -116,7 +116,6 @@ def setup(
 
     check_valid_checkpoint_dir(checkpoint_dir)
     config = Config.from_file(checkpoint_dir / "model_config.yaml")
-    config.fix_head_size = True
 
     if accelerator is None:
         accelerator = "cuda" if torch.cuda.is_available() else "cpu"

--- a/whittle/models/gpt/checkpoint.py
+++ b/whittle/models/gpt/checkpoint.py
@@ -123,8 +123,7 @@ def load_checkpoint(
         checkpoint_dir: The directory of the checkpoint.
         model_cls: The model class to instantiate. Defaults to GPT.
         config_cls: The config class to instantiate. Defaults to Config.
-        config_attr: The attributes to set in the config after __init__. If None, config.fix_head_size is set to True.
-            Defaults to None.
+        config_attr: The attributes to set in the config after __init__. Defaults to None.
 
     Returns:
         GPT: The loaded model.
@@ -155,11 +154,10 @@ def load_checkpoint(
             ckp = lazy_load(checkpoint_dir / "lit_model.pth")
 
     config = config_cls.from_file(checkpoint_dir / "model_config.yaml")
-    config_attr = {"fix_head_size": True} if config_attr is None else config_attr
-    for k, val in config_attr.items():
-        setattr(
-            config, k, val
-        )  # some args are not passed to __init__ - e.g. for config.fix_head_size = True
+    if config_attr is not None:
+        for k, val in config_attr.items():
+            # some args are not passed to __init__
+            setattr(config, k, val)
 
     model = model_cls(config)
     # for WhittleLM - it loads AutoTokenizer inside - either we copied it to checkpoint_dir, or it is referenced in parent_dir

--- a/whittle/models/gpt/model.py
+++ b/whittle/models/gpt/model.py
@@ -542,18 +542,10 @@ class GPT(nn.Module):
             else self.config.n_query_groups
         )
 
-        if self.config.fix_head_size:  # TODO: Deprecate. Not used (always set to True)
-            if sub_network_sizes["sub_network_head_size"] is None:
-                self.sub_network_head_size = self.config.head_size
-            else:
-                self.sub_network_head_size = sub_network_sizes["sub_network_head_size"]
+        if sub_network_sizes["sub_network_head_size"] is None:
+            self.sub_network_head_size = self.config.head_size
         else:
-            if sub_network_sizes["sub_network_head_size"] is not None:
-                self.sub_network_head_size = sub_network_sizes["sub_network_head_size"]
-            else:
-                self.sub_network_head_size = (
-                    self.sub_network_n_embd // self.sub_network_num_heads
-                )
+            self.sub_network_head_size = sub_network_sizes["sub_network_head_size"]
 
         if sampled_layer_indices is not None:
             for i, j in enumerate(sampled_layer_indices):

--- a/whittle/pretrain_super_network.py
+++ b/whittle/pretrain_super_network.py
@@ -164,7 +164,6 @@ def setup(
     data = TinyLlama() if data is None else data
 
     config = Config.from_name(model_name) if model_config is None else model_config
-    config.fix_head_size = True
 
     precision = precision or get_default_supported_precision(training=True)
     num_devices = parse_devices(devices)

--- a/whittle/prune.py
+++ b/whittle/prune.py
@@ -86,7 +86,6 @@ def setup(
 
     check_valid_checkpoint_dir(checkpoint_dir)
     config = Config.from_file(checkpoint_dir / "model_config.yaml")
-    config.fix_head_size = True
 
     if accelerator is None:
         accelerator = "cuda" if torch.cuda.is_available() else "cpu"

--- a/whittle/search_sub_networks.py
+++ b/whittle/search_sub_networks.py
@@ -121,7 +121,6 @@ def setup(
 
     check_valid_checkpoint_dir(checkpoint_dir)
     config = Config.from_file(checkpoint_dir / "model_config.yaml")
-    config.fix_head_size = True
 
     precision = precision or get_default_supported_precision(training=True)
     logger = choose_logger(

--- a/whittle/store_teacher_logits.py
+++ b/whittle/store_teacher_logits.py
@@ -71,7 +71,6 @@ def setup(
 
     print(f"Loading teacher model config from {teacher_checkpoint_dir}")
     config = Config.from_file(teacher_checkpoint_dir / "model_config.yaml")
-    config.fix_head_size = True
 
     hparams = capture_hparams()
     data = TinyStories() if data is None else data


### PR DESCRIPTION
#### Reference Issues/PRs

N/A — internal cleanup of a long-deprecated config flag.

#### What does this implement/fix? Explain your changes.

Removes `config.fix_head_size` entirely. Every entry-point script already hard-set it to `True`, the `False` branch in `GPT.set_sub_network` was flagged for deprecation, and it was only ever read in a single place.

- `whittle/models/gpt/model.py`: collapse the `if self.config.fix_head_size` branch in `set_sub_network` — `sub_network_head_size` now always defaults to `config.head_size` when the caller does not pass one explicitly.
- `whittle/models/gpt/checkpoint.py`: drop the implicit `{"fix_head_size": True}` default in `load_checkpoint`; `config_attr` is applied only when provided.
- `whittle/evaluate_network.py`: drop the flag from the `config_attr` dict.
- `convert.py`, `convert_to_litgpt.py`, `distill.py`, `full_finetune.py`, `pretrain_super_network.py`, `prune.py`, `search_sub_networks.py`, `store_teacher_logits.py`: drop the `config.fix_head_size = True` lines.
- Tests: strip all `config.fix_head_size = …` assignments; remove the `fix_head_size is True` assertion in `test_model_checkpoint.py`; in `test_attention.py` flatten `attention_configs` to `{name: Config}` and delete the three `*_flexible_head_size` variants, which only exercised the removed scaling branch.

#### Minimal Example / How should this PR be tested?

```bash
pytest test/
```

All previously passing tests should still pass. Sub-network forward behavior is unchanged because every call site already used the `fix_head_size=True` semantics.

#### Any other comments?

No migration shim — the flag had no external users and the removed `False` branch was documented as deprecated in-source.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.