### PR TITLE
refactor: tidy package exports and fix broken imports in compute_importance/convert

### DIFF
--- a/whittle/__init__.py
+++ b/whittle/__init__.py
@@ -1,0 +1,23 @@
+"""Whittle: compressing large language models by extracting sub-networks.
+
+The central object is `GPT`, which serves as both the super-network and any
+sub-network carved out of it. Calling `GPT.set_sub_network` reshapes the forward
+pass without re-allocating weights; `extract_current_sub_network` materialises
+the currently active sub-network as a stand-alone model.
+"""
+
+from __future__ import annotations
+
+from whittle.__version__ import __version__
+from whittle.models.gpt import GPT
+from whittle.models.gpt.checkpoint import load_checkpoint, save_sub_network
+from whittle.models.gpt.extract import extract_current_sub_network, extract_sub_network
+
+__all__ = [
+    "GPT",
+    "extract_current_sub_network",
+    "extract_sub_network",
+    "load_checkpoint",
+    "save_sub_network",
+    "__version__",
+]

--- a/whittle/compute_importance.py
+++ b/whittle/compute_importance.py
@@ -5,33 +5,35 @@ import io
 import json
 import os
 import pickle
+from typing import Any
 
 import numpy as np
 import torch
 import transformers
 from litgpt import Config
 
-from importance.block_importance import (
+from whittle.importance.block_importance import (
     compute_block_importance,
     compute_order_block_importance,
 )
-from importance.drop_layer import compute_order_layers_ppl
-from importance.embd_size import compute_importance_embd, compute_order_embd
-from importance.intermediate_size import (
+from whittle.importance.drop_layer import compute_order_layers_ppl
+from whittle.importance.embd_size import compute_importance_embd, compute_order_embd
+from whittle.importance.intermediate_size import (
     compute_importance_intermediate_size,
     compute_order_intermediate_dims,
 )
-from importance.num_heads import (
+from whittle.importance.num_heads import (
     compute_importance_head_groups,
     compute_importance_heads,
     compute_order_head_groups,
     compute_order_heads,
 )
-from importance.utils import evaluate_wikitext
-from metrics.parameters import compute_parameters
-from models.gpt.model import GPT
-from sampling.random_sampler import RandomSampler
-from search.search_spaces import search_spaces
+from whittle.importance.utils import evaluate_wikitext
+from whittle.metrics.parameters import compute_parameters
+from whittle.models.gpt.extract import extract_current_sub_network
+from whittle.models.gpt.model import GPT
+from whittle.sampling.random_sampler import RandomSampler
+from whittle.search.search_spaces import search_spaces
 
 
 def get_configs(sampler: RandomSampler, n: int = 5) -> list[dict]:
@@ -50,9 +52,9 @@ def evaluate_configs(
     configs: list[dict],
     search_space: object,
     layer_order: list[int] | None = None,
-) -> tuple[list[float], list[int]]:
+) -> tuple[list[float], list[float]]:
     ppls: list[float] = []
-    params: list[int] = []
+    params: list[float] = []
     for c in configs:
         if layer_order is None:
             model.set_sub_network(**space.cast(c))
@@ -120,7 +122,7 @@ if __name__ == "__main__":
     device = "cuda" if torch.cuda.is_available() else "cpu"
     model = GPT(config, compute_importance=True)
 
-    model.name_or_path = os.path.join("checkpoints", model_id)
+    model.name_or_path = os.path.join("checkpoints", model_id)  # type: ignore[assignment]
     model.load_state_dict(torch.load(model_path, map_location="cpu"))
     model.to(torch.bfloat16)
     model.to(device)
@@ -133,7 +135,7 @@ if __name__ == "__main__":
     sampler = RandomSampler(space.config_space, seed=args.seed)
     configs = get_configs(sampler=sampler, n=args.n_configs)
 
-    largest_model_config: dict[str, object] = {
+    largest_model_config: dict[str, Any] = {
         "sub_network_n_embd": config.n_embd,
         "sub_network_intermediate_size": [config.intermediate_size] * config.n_layer,
         "sub_network_num_heads": [config.n_head] * config.n_layer,
@@ -247,8 +249,6 @@ if __name__ == "__main__":
 
     print("PPL of full network before", before_sorting)
     print("PPL of full network after", after_sorting)
-
-    from models.gpt.extract import extract_current_sub_network
 
     permuted_model = extract_current_sub_network(model)
     permuted_model.to(torch.bfloat16)

--- a/whittle/convert.py
+++ b/whittle/convert.py
@@ -37,10 +37,17 @@ def create_litgpt_config_for_subnet(supernet):
 
 def copy_weights_to_litgpt(whittle_model, lit_model):
     def _copy_weights_and_biases(whittle_module, lit_module):
-        if hasattr(whittle_module, "extract_weights"):
-            W, b = whittle_module.extract_weights()
-        else:
-            print(f"{whittle_module} has no method extract_weights")
+        # Norm slots are nn.Identity when the config disables them. LitGPT uses
+        # nn.Identity in the same positions, so there is nothing to copy.
+        if isinstance(whittle_module, torch.nn.Identity):
+            return
+
+        if not hasattr(whittle_module, "extract_weights"):
+            raise TypeError(
+                f"Cannot convert {type(whittle_module).__name__} to LitGPT: expected a "
+                "Whittle module exposing extract_weights()."
+            )
+        W, b = whittle_module.extract_weights()
 
         if hasattr(lit_module, "weight"):
             w_data = W.data

--- a/whittle/models/gpt/__init__.py
+++ b/whittle/models/gpt/__init__.py
@@ -7,19 +7,19 @@ import re
 from lightning_utilities.core.imports import RequirementCache
 from litgpt import Config
 
-from whittle.models.gpt.model import GPT, Block
+from whittle.models.gpt.blocks import Block
+from whittle.models.gpt.model import GPT
 
 _LIGHTNING_AVAILABLE = RequirementCache("lightning>=2.2.0.dev0")
 if not bool(_LIGHTNING_AVAILABLE):
     raise ImportError(
-        "Lit-GPT requires lightning nightly. Please run:\n"
-        f" pip uninstall -y lightning; pip install -r requirements.txt\n{str(_LIGHTNING_AVAILABLE)}"
+        f"whittle requires lightning>=2.2.0. Please run:\n pip install -U lightning\n{_LIGHTNING_AVAILABLE}"
     )
 
 # Suppress excessive warnings, see https://github.com/pytorch/pytorch/issues/111632
-pattern = re.compile(".*Profiler function .* will be ignored")
+_pattern = re.compile(".*Profiler function .* will be ignored")
 logging.getLogger("torch._dynamo.variables.torch").addFilter(
-    lambda record: not pattern.search(record.getMessage())
+    lambda record: not _pattern.search(record.getMessage())
 )
 
 # Avoid printing state-dict profiling output at the WARNING level when saving a checkpoint

--- a/whittle/models/gpt/model.py
+++ b/whittle/models/gpt/model.py
@@ -508,7 +508,6 @@ class GPT(nn.Module):
             sampled_layer_indices=sampled_layer_indices,
             sampled_embd_indices=sampled_embd_indices,
         )
-        print(sub_network_sizes)
         self._verify_sub_network(
             **sub_network_sizes,
             sampled_intermediate_indices=sampled_intermediate_indices,

--- a/whittle/modules/__init__.py
+++ b/whittle/modules/__init__.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from .embedding import Embedding
+from .layernorm import LayerNorm
 from .linear import Linear
+from .rmsnorm import RMSNorm
 
-__all__ = ["Linear"]
+__all__ = ["Embedding", "LayerNorm", "Linear", "RMSNorm"]


### PR DESCRIPTION
#### Reference Issues/PRs

None — follow-up cleanup on top of #370 (`feat: add code for importance sorting`), which landed with a few rough edges.

#### What does this implement/fix? Explain your changes.

Small maintenance pass over the package surface and a couple of correctness issues:

- **`whittle/__init__.py`: expose the sub-network API at package level.** The top-level package was empty, so users had to reach into `whittle.models.gpt.*` for the core entry points. It now re-exports `GPT`, `extract_sub_network`, `extract_current_sub_network`, `load_checkpoint`, `save_sub_network` and `__version__`, with a module docstring describing the super-network / sub-network model.
- **`whittle/compute_importance.py`: fix broken imports.** The module imported `importance.*`, `metrics.*`, `models.*`, `sampling.*` and `search.*` as top-level packages, which only resolves when running from inside the `whittle/` directory — `import whittle.compute_importance` raised `ModuleNotFoundError`. Switched to absolute `whittle.*` imports and hoisted the function-local `extract_current_sub_network` import to the top. Also fixed the `evaluate_configs` return annotation (`compute_parameters` returns floats, not ints) and typed `largest_model_config` as `dict[str, Any]` so `mypy` accepts the heterogeneous values.
- **`whittle/convert.py`: handle disabled norms and fail loudly otherwise.** `_copy_weights_and_biases` previously `print`ed a message and then fell through to use undefined `W`/`b` for any module without `extract_weights`, raising `UnboundLocalError` well away from the actual cause. Norm slots are `nn.Identity` when the config disables them (e.g. `norm_qk`, post-norms) and LitGPT uses `nn.Identity` in the same positions, so those are now skipped explicitly; anything else raises a `TypeError` naming the offending module type.
- **`whittle/models/gpt/model.py`: drop a stray `print(sub_network_sizes)`** left in `GPT.set_sub_network`, which spammed stdout on every sub-network selection (including inside search loops).
- **`whittle/models/gpt/__init__.py`: import `Block` from `whittle.models.gpt.blocks`** rather than re-importing it through `model`, refresh the stale Lightning `ImportError` message (it pointed at `requirements.txt` and a `pip uninstall` dance inherited from Lit-GPT), and privatise the module-level `pattern` global.
- **`whittle/modules/__init__.py`: export `Embedding`, `LayerNorm` and `RMSNorm`** alongside `Linear`, so the sliceable-module package is importable as a unit.

No behavioural change to `set_sub_network` / `extract_*` semantics — the only runtime differences are the removed print, the `nn.Identity` skip, and the raise replacing an `UnboundLocalError`.

#### Minimal Example / How should this PR be tested?

The existing suite covers the touched paths (`test/test_model.py`, `test/test_extract.py`, `test/test_convert_to_litgpt.py`):

```bash
pytest
ruff check . && ruff format --check .
mypy whittle
```

The new package-level exports and the previously broken module can be smoke-tested with:

```python
from whittle import GPT, extract_current_sub_network, load_checkpoint, __version__
import whittle.compute_importance  # used to raise ModuleNotFoundError
```

#### Any other comments?

`whittle/compute_importance.py` is still a script-style module with its logic under `if __name__ == "__main__":`; this PR only makes it importable and type-clean, it does not restructure it into a proper entry point. The four commits are independent — happy to split any of them out if you'd rather review them separately.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
