### PR TITLE
refactor: tidy package exports and cleanup

### DIFF
--- a/whittle/__init__.py
+++ b/whittle/__init__.py
@@ -1,0 +1,23 @@
+"""Whittle: compressing large language models by extracting sub-networks.
+
+The central object is `GPT`, which serves as both the super-network and any
+sub-network carved out of it. Calling `GPT.set_sub_network` reshapes the forward
+pass without re-allocating weights; `extract_current_sub_network` materialises
+the currently active sub-network as a stand-alone model.
+"""
+
+from __future__ import annotations
+
+from whittle.__version__ import __version__
+from whittle.models.gpt import GPT
+from whittle.models.gpt.checkpoint import load_checkpoint, save_sub_network
+from whittle.models.gpt.extract import extract_current_sub_network, extract_sub_network
+
+__all__ = [
+    "GPT",
+    "extract_current_sub_network",
+    "extract_sub_network",
+    "load_checkpoint",
+    "save_sub_network",
+    "__version__",
+]

--- a/whittle/convert.py
+++ b/whittle/convert.py
@@ -37,10 +37,17 @@ def create_litgpt_config_for_subnet(supernet):
 
 def copy_weights_to_litgpt(whittle_model, lit_model):
     def _copy_weights_and_biases(whittle_module, lit_module):
-        if hasattr(whittle_module, "extract_weights"):
-            W, b = whittle_module.extract_weights()
-        else:
-            print(f"{whittle_module} has no method extract_weights")
+        # Norm slots are nn.Identity when the config disables them. LitGPT uses
+        # nn.Identity in the same positions, so there is nothing to copy.
+        if isinstance(whittle_module, torch.nn.Identity):
+            return
+
+        if not hasattr(whittle_module, "extract_weights"):
+            raise TypeError(
+                f"Cannot convert {type(whittle_module).__name__} to LitGPT: expected a "
+                "Whittle module exposing extract_weights()."
+            )
+        W, b = whittle_module.extract_weights()
 
         if hasattr(lit_module, "weight"):
             w_data = W.data

--- a/whittle/models/gpt/__init__.py
+++ b/whittle/models/gpt/__init__.py
@@ -7,19 +7,19 @@ import re
 from lightning_utilities.core.imports import RequirementCache
 from litgpt import Config
 
-from whittle.models.gpt.model import GPT, Block
+from whittle.models.gpt.blocks import Block
+from whittle.models.gpt.model import GPT
 
 _LIGHTNING_AVAILABLE = RequirementCache("lightning>=2.2.0.dev0")
 if not bool(_LIGHTNING_AVAILABLE):
     raise ImportError(
-        "Lit-GPT requires lightning nightly. Please run:\n"
-        f" pip uninstall -y lightning; pip install -r requirements.txt\n{str(_LIGHTNING_AVAILABLE)}"
+        f"whittle requires lightning>=2.2.0. Please run:\n pip install -U lightning\n{_LIGHTNING_AVAILABLE}"
     )
 
 # Suppress excessive warnings, see https://github.com/pytorch/pytorch/issues/111632
-pattern = re.compile(".*Profiler function .* will be ignored")
+_pattern = re.compile(".*Profiler function .* will be ignored")
 logging.getLogger("torch._dynamo.variables.torch").addFilter(
-    lambda record: not pattern.search(record.getMessage())
+    lambda record: not _pattern.search(record.getMessage())
 )
 
 # Avoid printing state-dict profiling output at the WARNING level when saving a checkpoint

--- a/whittle/models/gpt/model.py
+++ b/whittle/models/gpt/model.py
@@ -508,7 +508,6 @@ class GPT(nn.Module):
             sampled_layer_indices=sampled_layer_indices,
             sampled_embd_indices=sampled_embd_indices,
         )
-        print(sub_network_sizes)
         self._verify_sub_network(
             **sub_network_sizes,
             sampled_intermediate_indices=sampled_intermediate_indices,

--- a/whittle/modules/__init__.py
+++ b/whittle/modules/__init__.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from .embedding import Embedding
+from .layernorm import LayerNorm
 from .linear import Linear
+from .rmsnorm import RMSNorm
 
-__all__ = ["Linear"]
+__all__ = ["Embedding", "LayerNorm", "Linear", "RMSNorm"]


### PR DESCRIPTION
Cleanup pass, no functional change to sub-network behaviour:

- Remove a stray debug `print(sub_network_sizes)` from `GPT.set_sub_network`.
- `convert.py`: skip `nn.Identity` norm slots (LitGPT uses `nn.Identity` in the same positions, so there is nothing to copy) and raise `TypeError` instead of printing when a module has no `extract_weights()`.
- Add a package-level `whittle/__init__.py` exporting `GPT`, `extract_sub_network`, `extract_current_sub_network`, `load_checkpoint`, `save_sub_network`, `__version__`.
- Export `Embedding`/`LayerNorm`/`RMSNorm` alongside `Linear` from `whittle.modules`; import `Block` from `whittle.models.gpt.blocks` directly; refresh the stale lightning-nightly ImportError message.

Split out of #372.